### PR TITLE
ITLP [PR 2/2]: Expose ITLP planning adapter

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -741,15 +741,8 @@ class MoveGroupCommander(object):
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)
         ser_traj_in = conversions.msg_to_string(traj_in)
         ser_gravity_vector = conversions.msg_to_string(gravity_vector)
-        if external_link_wrenches is None:
-            zero_wrench = Wrench(
-                force=Vector3(0.0, 0.0, 0.0), torque=Vector3(0.0, 0.0, 0.0)
-            )
-            external_link_wrenches = [zero_wrench] * len(
-                self.get_active_joints()
-            )
         ser_external_link_wrenches = [
-            conversions.msg_to_string(w) for w in external_link_wrenches
+            conversions.msg_to_string(w) for w in external_link_wrenches or []
         ]
         if joint_torque_limits is None:
             joint_torque_limits = []

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -32,6 +32,9 @@
 #
 # Author: Ioan Sucan, William Baker
 
+from typing import List
+from typing import Optional
+
 from geometry_msgs.msg import Pose, PoseStamped, Vector3, Wrench
 from moveit_msgs.msg import (
     RobotTrajectory,
@@ -728,16 +731,17 @@ class MoveGroupCommander(object):
 
     def retime_trajectory(
         self,
-        ref_state_in,
-        traj_in,
-        velocity_scaling_factor=1.0,
-        acceleration_scaling_factor=1.0,
-        algorithm="iterative_time_parameterization",
-        gravity_vector=Vector3(x=0.0, y=0.0, z=-9.81),
-        external_link_wrenches=None,
-        joint_torque_limits=None,
-        accel_limit_decrement_factor=0.1,
+        ref_state_in,  # type: RobotState
+        traj_in,  # type: RobotTrajectory
+        velocity_scaling_factor=1.0,  # type: float
+        acceleration_scaling_factor=1.0,  # type: float
+        algorithm="iterative_time_parameterization",  # type: str
+        gravity_vector=Vector3(x=0.0, y=0.0, z=-9.81),  # type: Vector3
+        external_link_wrenches=None,  # type: Optional[List[Wrench]]
+        joint_torque_limits=None,  # type: Optional[List[float]]
+        accel_limit_decrement_factor=0.1,  # type: float
     ):
+        # type: (...) -> RobotTrajectory
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)
         ser_traj_in = conversions.msg_to_string(traj_in)
         ser_gravity_vector = conversions.msg_to_string(gravity_vector)

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -32,7 +32,7 @@
 #
 # Author: Ioan Sucan, William Baker
 
-from geometry_msgs.msg import Pose, PoseStamped
+from geometry_msgs.msg import Pose, PoseStamped, Vector3, Wrench
 from moveit_msgs.msg import (
     RobotTrajectory,
     Grasp,
@@ -733,15 +733,36 @@ class MoveGroupCommander(object):
         velocity_scaling_factor=1.0,
         acceleration_scaling_factor=1.0,
         algorithm="iterative_time_parameterization",
+        gravity_vector=Vector3(x=0.0, y=0.0, z=-9.81),
+        external_link_wrenches=None,
+        joint_torque_limits=None,
+        accel_limit_decrement_factor=0.1,
     ):
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)
         ser_traj_in = conversions.msg_to_string(traj_in)
+        ser_gravity_vector = conversions.msg_to_string(gravity_vector)
+        if external_link_wrenches is None:
+            zero_wrench = Wrench(
+                force=Vector3(0.0, 0.0, 0.0), torque=Vector3(0.0, 0.0, 0.0)
+            )
+            external_link_wrenches = [zero_wrench] * len(
+                self.get_active_joints()
+            )
+        ser_external_link_wrenches = [
+            conversions.msg_to_string(w) for w in external_link_wrenches
+        ]
+        if joint_torque_limits is None:
+            joint_torque_limits = []
         ser_traj_out = self._g.retime_trajectory(
             ser_ref_state_in,
             ser_traj_in,
             velocity_scaling_factor,
             acceleration_scaling_factor,
             algorithm,
+            ser_gravity_vector,
+            ser_external_link_wrenches,
+            joint_torque_limits,
+            accel_limit_decrement_factor,
         )
         traj_out = RobotTrajectory()
         traj_out.deserialize(ser_traj_out)

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
@@ -57,20 +57,26 @@ public:
    * time-parameterized; this function will re-time-parameterize it.
    * \param gravity_vector For example, (0, 0, -9.81). Units are m/s^2
    * \param external_link_wrenches Externally-applied wrenches on each link. TODO(andyz): what frame is this in?
-   * \param joint_torque_limits Torque limits for each joint in N*m. Should all be >0.
+   * \param joint_torque_limits Torque limits for each joint in N*m. Should all be >0. TODO(cj): Populate from robot
+   *   description.
    * \param accel_limit_decrement_factor Typically in the range [0.01-0.1].
    * This affects how fast acceleration limits are decreased while searching for a solution. Time-optimality
    * of the output is accurate to approximately 100*accel_limit_decrement_factor %.
    * For example, if accel_limit_decrement_factor is 0.1, the output should be within 10% of time-optimal.
    * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
    * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param max_iterations Maximum number of times to do the TOTG->torque check->accel change loop. Default: 10.
+   * \param reset_traj_after_max_iterations Whether to reset `trajectory` to its initial state when more than
+   *   `max_iterations` iterations is needed to get all torques under their limits. Default: False, i.e. return the
+   *   result of the last iteration.
    */
   bool computeTimeStampsWithTorqueLimits(
       robot_trajectory::RobotTrajectory& trajectory, const geometry_msgs::Vector3& gravity_vector,
       const std::vector<geometry_msgs::Wrench>& external_link_wrenches, const std::vector<double>& joint_torque_limits,
       double accel_limit_decrement_factor, const std::unordered_map<std::string, double>& velocity_limits,
       const std::unordered_map<std::string, double>& acceleration_limits, const double max_velocity_scaling_factor,
-      const double max_acceleration_scaling_factor) const;
+      const double max_acceleration_scaling_factor, const size_t max_iterations = 10,
+      const bool reset_trajectory_after_max_iterations = false) const;
 
 private:
   TimeOptimalTrajectoryGeneration totg_;

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
@@ -57,7 +57,7 @@ public:
    * time-parameterized; this function will re-time-parameterize it.
    * \param gravity_vector For example, (0, 0, -9.81). Units are m/s^2
    * \param external_link_wrenches Externally-applied wrenches on each link. TODO(andyz): what frame is this in?
-   * \param joint_torque_limits Torque limits for each joint in N*m. Should all be >0. TODO(cj): Populate from robot
+   * \param joint_torque_limits Torque limits for each joint in N*m. All should be >0. TODO(cj): Populate from robot
    *   description.
    * \param accel_limit_decrement_factor Typically in the range [0.01-0.1].
    * This affects how fast acceleration limits are decreased while searching for a solution. Time-optimality

--- a/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
@@ -41,6 +41,8 @@ namespace trajectory_processing
 namespace
 {
 const std::string LOGNAME = "trajectory_processing.iterative_torque_limit_parameterization";
+constexpr double DEFAULT_VELOCITY_LIMIT = 1.0;
+constexpr double DEFAULT_ACCELERATION_LIMIT = 1.0;
 }
 
 IterativeTorqueLimitParameterization::IterativeTorqueLimitParameterization(const double path_tolerance,
@@ -55,7 +57,8 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     const std::vector<geometry_msgs::Wrench>& external_link_wrenches, const std::vector<double>& joint_torque_limits,
     double accel_limit_decrement_factor, const std::unordered_map<std::string, double>& velocity_limits,
     const std::unordered_map<std::string, double>& acceleration_limits, const double max_velocity_scaling_factor,
-    const double max_acceleration_scaling_factor) const
+    const double max_acceleration_scaling_factor, const size_t max_iterations,
+    const bool reset_trajectory_after_max_iterations) const
 {
   // 1. Call computeTimeStamps() to time-parameterize the trajectory with given vel/accel limits.
   // 2. Run forward dynamics to check if torque limits are violated at any waypoint.
@@ -70,9 +73,6 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     ROS_ERROR_NAMED(LOGNAME, "It looks like the planner did not set the group the plan was computed for");
     return false;
   }
-
-  // Create a mutable copy of acceleration_limits
-  std::unordered_map<std::string, double> mutable_accel_limits = acceleration_limits;
 
   size_t dof = group->getActiveJointModels().size();
 
@@ -90,6 +90,87 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     return false;
   }
 
+  /* Create a mutable copy of `velocity_limits` and `acceleration_limits`;
+   * fill them in from the robot description if they are empty.
+   * TODO(cj): Factor out limit resolution; common/duplicated in TOTG as well.
+   */
+  std::unordered_map<std::string, double> mutable_vel_limits = velocity_limits;
+  std::unordered_map<std::string, double> mutable_accel_limits = acceleration_limits;
+
+  // Lambda for validating limits
+  auto validate_limit = [](const char* type, double value, const std::string& name) {
+    if (value <= std::numeric_limits<double>::epsilon())
+    {
+      ROS_ERROR_NAMED(LOGNAME, "Invalid %s limit %f for joint '%s'. Must be greater than zero!", type, value,
+                      name.c_str());
+      return false;
+    }
+    return true;
+  };
+
+  const std::vector<std::string>& joint_names = group->getActiveJointModelNames();
+  size_t num_joints = joint_names.size();
+  const robot_model::JointBoundsVector joint_bounds = group->getActiveJointModelsBounds();
+
+  for (size_t j = 0; j < num_joints; ++j)
+  {
+    const std::string& name = joint_names[j];
+    // Each element in joint_bounds is a pointer to a Bounds (i.e., vector<VariableBounds>)
+    const robot_model::JointModel::Bounds* bounds_ptr = joint_bounds[j];
+    if (bounds_ptr->size() != 1)
+    {
+      ROS_ERROR_NAMED(LOGNAME, "Cannot handle bounds for multi-variable joint '%s'!", name.c_str());
+      return false;
+    }
+    const moveit::core::VariableBounds vb = (*bounds_ptr)[0];
+
+    // Resolve velocity limit: Fill in if not already provided.
+    auto it = mutable_vel_limits.find(name);
+    if (it == mutable_vel_limits.end())
+    {
+      if (vb.velocity_bounded_)
+      {
+        double limit = std::min(std::fabs(vb.max_velocity_), std::fabs(vb.min_velocity_));
+        if (!validate_limit("velocity", limit, name))
+          return false;
+        mutable_vel_limits[name] = limit;
+      }
+      else
+      {
+        mutable_vel_limits[name] = DEFAULT_VELOCITY_LIMIT;
+        ROS_WARN_ONCE_NAMED(LOGNAME,
+          "No velocity limits defined for '%s'! Define them in URDF or joint_limits.yaml", name.c_str());
+      }
+    }
+    else {
+      if (!validate_limit("velocity", it->second, name))
+        return false;
+    }
+
+    // Resolve acceleration limit: Fill in if not already provided.
+    it = mutable_accel_limits.find(name);
+    if (it == mutable_accel_limits.end())
+    {
+      if (vb.acceleration_bounded_)
+      {
+        double limit = std::min(std::fabs(vb.max_acceleration_), std::fabs(vb.min_acceleration_));
+        if (!validate_limit("acceleration", limit, name))
+          return false;
+        mutable_accel_limits[name] = limit;
+      }
+      else
+      {
+        mutable_accel_limits[name] = DEFAULT_ACCELERATION_LIMIT;
+        ROS_WARN_ONCE_NAMED(LOGNAME,
+          "No acceleration limits defined for '%s'! Define them in joint_limits.yaml", name.c_str());
+      }
+    }
+    else {
+      if (!validate_limit("acceleration", it->second, name))
+        return false;
+    }
+  }
+
   dynamics_solver::DynamicsSolver dynamics_solver(trajectory.getRobotModel(), group->getName(), gravity_vector);
 
   // Copy the waypoints so we can modify them while iterating
@@ -99,14 +180,15 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
 
   bool iteration_needed = true;
   size_t num_iterations = 0;
-  const size_t max_iterations = 10;
 
   while (iteration_needed && num_iterations < max_iterations)
   {
     ++num_iterations;
     iteration_needed = false;
 
-    totg_.computeTimeStamps(trajectory, velocity_limits, mutable_accel_limits, max_velocity_scaling_factor,
+    // TOTG is always run on the same trajectory;`mutable_accel_limits` is the only thing changing across iterations.
+    trajectory.setRobotTrajectoryMsg(initial_state, original_traj);
+    totg_.computeTimeStamps(trajectory, mutable_vel_limits, mutable_accel_limits, max_velocity_scaling_factor,
                             max_acceleration_scaling_factor);
 
     std::vector<double> joint_positions(dof);
@@ -164,7 +246,6 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
             mutable_accel_limits.at(joint_models.at(joint_idx)->getName()) *= (1 - accel_limit_decrement_factor);
           }
 
-          mutable_accel_limits.at(joint_models.at(joint_idx)->getName()) *= (1 - accel_limit_decrement_factor);
           iteration_needed = true;
         }
       }  // for each joint
@@ -174,13 +255,20 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
         break;
       }
     }  // for each waypoint
+  }  // while (iteration_needed && num_iterations < max_iterations)
 
-    if (iteration_needed)
+  if (num_iterations >= max_iterations && iteration_needed)
+  {
+    if (reset_trajectory_after_max_iterations)
     {
-      // Reset
+      ROS_WARN_STREAM_NAMED(LOGNAME, "ITLP needs more than max_iterations; resetting trajectory");
       trajectory.setRobotTrajectoryMsg(initial_state, original_traj);
     }
-  }  // while (iteration_needed && num_iterations < max_iterations)
+    else
+    {
+      ROS_WARN_STREAM_NAMED(LOGNAME, "Trajectory still violates torque limits!");
+    }
+  }
 
   return true;
 }

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -6,9 +6,10 @@ set(SOURCE_FILES
   src/fix_start_state_collision.cpp
   src/fix_start_state_path_constraints.cpp
   src/fix_workspace_bounds.cpp
-  src/add_time_parameterization.cpp
   src/add_iterative_spline_parameterization.cpp
-  src/add_time_optimal_parameterization.cpp)
+  src/add_iterative_iterative_torque_limit_parameterization.cpp
+  src/add_time_optimal_parameterization.cpp
+  src/add_time_parameterization.cpp)
 
 add_library(${MOVEIT_LIB_NAME} ${SOURCE_FILES})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SOURCE_FILES
   src/fix_start_state_path_constraints.cpp
   src/fix_workspace_bounds.cpp
   src/add_iterative_spline_parameterization.cpp
-  src/add_iterative_iterative_torque_limit_parameterization.cpp
+  src/add_iterative_torque_limit_parameterization.cpp
   src/add_time_optimal_parameterization.cpp
   src/add_time_parameterization.cpp)
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -1,15 +1,15 @@
 set(MOVEIT_LIB_NAME moveit_default_planning_request_adapter_plugins)
 
 set(SOURCE_FILES
+  src/add_iterative_spline_parameterization.cpp
+  src/add_iterative_torque_limit_parameterization.cpp
+  src/add_time_optimal_parameterization.cpp
+  src/add_time_parameterization.cpp
   src/empty.cpp
   src/fix_start_state_bounds.cpp
   src/fix_start_state_collision.cpp
   src/fix_start_state_path_constraints.cpp
-  src/fix_workspace_bounds.cpp
-  src/add_iterative_spline_parameterization.cpp
-  src/add_iterative_torque_limit_parameterization.cpp
-  src/add_time_optimal_parameterization.cpp
-  src/add_time_parameterization.cpp)
+  src/fix_workspace_bounds.cpp)
 
 add_library(${MOVEIT_LIB_NAME} ${SOURCE_FILES})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_torque_limit_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_torque_limit_parameterization.cpp
@@ -1,0 +1,86 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, Chef Robotics, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Chef Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: C.J. Geering */
+
+#include <moveit/planning_request_adapter/planning_request_adapter.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+#include <class_loader/class_loader.hpp>
+#include <ros/console.h>
+
+namespace default_planner_request_adapters
+{
+using namespace trajectory_processing;
+
+/** @brief This adapter uses the Iterative Torque Limit Parameterization method */
+class AddIterativeTorqueLimitParameterization : public planning_request_adapter::PlanningRequestAdapter
+{
+public:
+  AddIterativeTorqueLimitParameterization() : planning_request_adapter::PlanningRequestAdapter()
+  {
+  }
+
+  std::string getDescription() const override
+  {
+    return "Add Iterative Torque Limit Parameterization";
+  }
+
+  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
+                    std::vector<std::size_t>& added_path_index) const override
+  {
+    bool result = planner(planning_scene, req, res);
+    if (result && res.trajectory_)
+    {
+      ROS_DEBUG("Running '%s'", getDescription().c_str());
+      // TODO(cj): Extend MotionPlanRequest msg to support ITLP -- needs: gravity vector, external wrenches,
+      // joint torque limits, acceleration limit decrement factor, velocity limits, and acceleration limits.
+      ROS_WARN("Using TOTG because ITLP cannot be configured from a MotionPlanRequest message!")
+      TimeOptimalTrajectoryGeneration totg;
+      if (!totg.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
+                                  req.max_acceleration_scaling_factor))
+      {
+        ROS_ERROR("Time parametrization for the solution path failed.");
+        result = false;
+      }
+    }
+
+    return result;
+  }
+};
+
+}  // namespace default_planner_request_adapters
+
+CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AddIterativeTorqueLimitParameterization,
+                            planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_torque_limit_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_torque_limit_parameterization.cpp
@@ -66,7 +66,7 @@ public:
       ROS_DEBUG("Running '%s'", getDescription().c_str());
       // TODO(cj): Extend MotionPlanRequest msg to support ITLP -- needs: gravity vector, external wrenches,
       // joint torque limits, acceleration limit decrement factor, velocity limits, and acceleration limits.
-      ROS_WARN("Using TOTG because ITLP cannot be configured from a MotionPlanRequest message!")
+      ROS_WARN("Using TOTG because ITLP cannot be configured from a MotionPlanRequest message!");
       TimeOptimalTrajectoryGeneration totg;
       if (!totg.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
                                   req.max_acceleration_scaling_factor))

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -41,4 +41,14 @@
     </description>
   </class>
 
+    <class name="default_planner_request_adapters/AddIterativeTorqueLimitParameterization" type="default_planner_request_adapters::AddIterativeTorqueLimitParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
+    <description>
+      Time-parameterize a trajectory with Time-Optimal Trajectory Generation, then refine until torque limits are obeyed.
+
+      NB: When called via MotionPlanRequest, e.g. as part of a planning pipeline, then only TOTG is performed;
+          the torque refinement requires extra planning params that are not provided by MotionPlanRequest. When called
+          directly, e.g. MoveGroupInterface.retime_trajectory(), then the torque refinement is performed.
+    </description>
+  </class>
+
 </library>

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -587,14 +587,14 @@ public:
           trajectory_processing::IterativeParabolicTimeParameterization time_param;
           time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
         }
-        else if (algorithm == "iterative_torque_limit_parameterization")
-        {
-          trajectory_processing::IterativeTorqueLimitParameterization time_param;
-          time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
-        }
         else if (algorithm == "iterative_spline_parameterization")
         {
           trajectory_processing::IterativeSplineParameterization time_param;
+          time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
+        }
+        else if (algorithm == "iterative_torque_limit_parameterization")
+        {
+          trajectory_processing::IterativeTorqueLimitParameterization time_param;
           geometry_msgs::Vector3 gravity_vector_msg;
           py_bindings_tools::deserializeMsg(gravity_vector_str, gravity_vector_msg);
           std::vector<geometry_msgs::Wrench> external_link_wrenches;

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -577,12 +577,13 @@ public:
       py_bindings_tools::deserializeMsg(traj_str, traj_msg);
       bool algorithm_found = true;
 
-      geometry_msgs::Vector3 gravity_vector_msg;
+      // Conversions for ITLP; need to do these before GIL is released.
+      geometry_msgs::Vector3 gravity_vector;
       std::vector<geometry_msgs::Wrench> external_link_wrenches;
       std::vector<double> joint_torque_limits;
       if (algorithm == "iterative_torque_limit_parameterization")
       {
-        py_bindings_tools::deserializeMsg(gravity_vector_str, gravity_vector_msg);
+        py_bindings_tools::deserializeMsg(gravity_vector_str, gravity_vector);
 
         if (bp::len(external_link_wrenches_list) == 0) {
           const robot_model::JointModelGroup* group = ref_state_obj.getJointModelGroup(getName());
@@ -615,7 +616,7 @@ public:
         {
           trajectory_processing::IterativeTorqueLimitParameterization time_param;
           std::unordered_map<std::string, double> empty;
-          time_param.computeTimeStampsWithTorqueLimits(traj_obj, gravity_vector_msg, external_link_wrenches,
+          time_param.computeTimeStampsWithTorqueLimits(traj_obj, gravity_vector, external_link_wrenches,
                                                        joint_torque_limits, accel_limit_decrement_factor,
                                                        empty, empty, velocity_scaling_factor,
                                                        acceleration_scaling_factor);

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -42,6 +42,7 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <moveit/trajectory_processing/iterative_torque_limit_parameterization.h>
 #include <moveit/trajectory_processing/iterative_spline_parameterization.h>
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <tf2_eigen/tf2_eigen.h>
@@ -543,10 +544,27 @@ public:
     return py_bindings_tools::serializeMsg(constraints_msg);
   }
 
+  // Convert a Python list of deserialized wrench messages to std::vector<geometry_msgs::Wrench>
+  void convertListToArrayOfWrenches(const bp::list& wrenches, std::vector<geometry_msgs::Wrench>& result) {
+    int len = bp::len(wrenches);
+    result.reserve(len);
+    for (int i = 0; i < len; ++i) {
+      const py_bindings_tools::ByteString& wrench_str = bp::extract<py_bindings_tools::ByteString>(wrenches[i]);
+      geometry_msgs::Wrench wrench_msg;
+      py_bindings_tools::deserializeMsg(wrench_str, wrench_msg);
+      result.push_back(wrench_msg);
+    }
+  }
+
   py_bindings_tools::ByteString retimeTrajectory(const py_bindings_tools::ByteString& ref_state_str,
                                                  const py_bindings_tools::ByteString& traj_str,
                                                  double velocity_scaling_factor, double acceleration_scaling_factor,
-                                                 const std::string& algorithm)
+                                                 const std::string& algorithm,
+                                                 /* The following params are only used for ITLP */
+                                                 const py_bindings_tools::ByteString& gravity_vector_str,
+                                                 const bp::list& external_link_wrenches_list,
+                                                 const bp::list& joint_torque_limits_list,
+                                                 const double accel_limit_decrement_factor)
   {
     // Convert reference state message to object
     moveit_msgs::RobotState ref_state_msg;
@@ -569,10 +587,24 @@ public:
           trajectory_processing::IterativeParabolicTimeParameterization time_param;
           time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
         }
+        else if (algorithm == "iterative_torque_limit_parameterization")
+        {
+          trajectory_processing::IterativeTorqueLimitParameterization time_param;
+          time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
+        }
         else if (algorithm == "iterative_spline_parameterization")
         {
           trajectory_processing::IterativeSplineParameterization time_param;
-          time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
+          geometry_msgs::Vector3 gravity_vector_msg;
+          py_bindings_tools::deserializeMsg(gravity_vector_str, gravity_vector_msg);
+          std::vector<geometry_msgs::Wrench> external_link_wrenches;
+          convertListToArrayOfWrenches(external_link_wrenches_list, external_link_wrenches);
+          std::vector<double> joint_torque_limits = py_bindings_tools::doubleFromList(joint_torque_limits_list);
+          std::unordered_map<std::string, double> empty;
+          time_param.computeTimeStampsWithTorqueLimits(traj_obj, gravity_vector_msg, external_link_wrenches,
+                                                       joint_torque_limits, accel_limit_decrement_factor,
+                                                       empty, empty, velocity_scaling_factor,
+                                                       acceleration_scaling_factor);
         }
         else if (algorithm == "time_optimal_trajectory_generation")
         {

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -564,7 +564,7 @@ public:
                                                  const py_bindings_tools::ByteString& gravity_vector_str,
                                                  const bp::list& external_link_wrenches_list,
                                                  const bp::list& joint_torque_limits_list,
-                                                 const double accel_limit_decrement_factor)
+                                                 double accel_limit_decrement_factor)
   {
     // Convert reference state message to object
     moveit_msgs::RobotState ref_state_msg;
@@ -576,6 +576,25 @@ public:
       moveit_msgs::RobotTrajectory traj_msg;
       py_bindings_tools::deserializeMsg(traj_str, traj_msg);
       bool algorithm_found = true;
+
+      geometry_msgs::Vector3 gravity_vector_msg;
+      std::vector<geometry_msgs::Wrench> external_link_wrenches;
+      std::vector<double> joint_torque_limits;
+      if (algorithm == "iterative_torque_limit_parameterization")
+      {
+        py_bindings_tools::deserializeMsg(gravity_vector_str, gravity_vector_msg);
+
+        if (bp::len(external_link_wrenches_list) == 0) {
+          const robot_model::JointModelGroup* group = ref_state_obj.getJointModelGroup(getName());
+          external_link_wrenches.resize(group ? group->getLinkModelNames().size() : 0);
+        }
+        else {
+          convertListToArrayOfWrenches(external_link_wrenches_list, external_link_wrenches);
+        }
+
+        joint_torque_limits = py_bindings_tools::doubleFromList(joint_torque_limits_list);
+      }
+
       {
         GILReleaser gr;
         robot_trajectory::RobotTrajectory traj_obj(getRobotModel(), getName());
@@ -595,11 +614,6 @@ public:
         else if (algorithm == "iterative_torque_limit_parameterization")
         {
           trajectory_processing::IterativeTorqueLimitParameterization time_param;
-          geometry_msgs::Vector3 gravity_vector_msg;
-          py_bindings_tools::deserializeMsg(gravity_vector_str, gravity_vector_msg);
-          std::vector<geometry_msgs::Wrench> external_link_wrenches;
-          convertListToArrayOfWrenches(external_link_wrenches_list, external_link_wrenches);
-          std::vector<double> joint_torque_limits = py_bindings_tools::doubleFromList(joint_torque_limits_list);
           std::unordered_map<std::string, double> empty;
           time_param.computeTimeStampsWithTorqueLimits(traj_obj, gravity_vector_msg, external_link_wrenches,
                                                        joint_torque_limits, accel_limit_decrement_factor,


### PR DESCRIPTION
### Description

This PR exposes ITLP as a planning request adapter. More importantly, it extends the `MoveGroupCommander.retime_trajectory()` method to support calling the `iterative_torque_limit_parameterization` retiming algorithm (ITLP) (for the most part, we access retiming via a `MoveGroupCommander` instance, not the planning adapter).

Three important changes to `computeTimeStamps()`:
1. Better resolution of joint velocity and acceleration limits (to match the behavior of TOTG); if missing, then use the limits in the robot model.
2. Argument for the maximum number of iterations, `max_iterations` (default to 10, which is the existing default).
3. Argument to specify whether to reset the trajectory -- or not -- if we hit `max_iterations` and still haven't converged, `reset_trajectory_after_max_iterations`; default to `false` because usually we still want the last parameterized traj, even if it didn't fully converge to be under the specified torque limits.

- [x] Build is successful.
- [x] ITLP unit tests pass.
- [x] ITLP planning adapter works
- [x] `MoveGroupCommander.retime_trajectory()` with algo set to `iterative_torque_limit_parameterization` works.



