### PR TITLE
:watch: :bug:  Revert to using a fixed integration timestep in TOTG

### DIFF
--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -1010,8 +1010,15 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(
   }
 
   // Now actually call the algorithm
-  // We use a smaller timestep for better accuracy
-  Trajectory parameterized(Path(points, path_tolerance_), max_velocity, max_acceleration, 0.1 * resample_dt_);
+  /*
+   * NB: We revert to a constant 1 ms integration step here rather than
+   * `0.1 * resample_dt_` because if the integration step is too large,
+   * then it can lead to poor trajectory fidelity and numerical instabilities.
+   * A fixed 1 ms step ensures consistent accuracy across all output rates,
+   * and avoids simulation artifacts that can arise with an adaptive step.
+   */
+  // Trajectory parameterized(Path(points, path_tolerance_), max_velocity, max_acceleration, 0.1 * resample_dt_);
+  Trajectory parameterized(Path(points, path_tolerance_), max_velocity, max_acceleration, 0.001);
   if (!parameterized.isValid())
   {
     ROS_ERROR_NAMED(LOGNAME, "Unable to parameterize trajectory.");


### PR DESCRIPTION
### Description

PR #3 had this [sneaky change](https://github.com/chef-robotics/moveit/blob/5804446b89c7af5258bec59d7e7310be5b33a0fd/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp#L1014), where the integration timestep used in TOTG was change from a fixed 0.001 s (1 ms) to a proportion of the `resample_dt_` (specifically, 10% of `resample_dt`). This change was undocumented by Moveit and just included in the ITLP feature -____-; it is also the behavior in Noetic.

This PR reverts from the adaptive timestep to the fixed timestep, which is what is used in Melodic TOTG.

ChefAutonomy sim test now don't flake. Why were they flaking due to this? See my NB in the code, but here's some more:
- TOTG class gets instantiated with `resample_dt_ := 0.1` (which is the default).
- So the effective timestep is `0.1 * 0.1 = 0.01`.
- This is 10x larger that the timestep were using.
- While I didn't inspect the trajs, I suspect `0.01` is too large of a step for some of our trajs, especially in conjunction with sim time.
- Yeah, we could consider making the integration timestep it's own arg, or testing out `resample_dt_ = 0.01` (but that might have other effects because resample_dt_ is used in other places); but right now I'm justr trying to restore parity.


Testing:
- [x] A/B testing of using `0.001` vs `0.1 * resample_dt_` with ChefAutonomy sim tests -- no failures when using `0.001` with 10 attempts; 9 failures when using `0.1 * resample_dt_` with 10 attempts.
- [x] Test on hw; make sure nothing weird happens with the trajectories.