### PR TITLE
:stopwatch: :recycle: Refactor `retimeTrajectory()` API

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -736,32 +736,45 @@ class MoveGroupCommander(object):
         velocity_scaling_factor=1.0,  # type: float
         acceleration_scaling_factor=1.0,  # type: float
         algorithm="iterative_time_parameterization",  # type: str
-        gravity_vector=Vector3(),  # type: Vector3
+        try_torque_stuffing=True,  # type: bool
+        gravity_vector=None,  # type: Optional[Vector3]
         external_link_wrenches=None,  # type: Optional[List[Wrench]]
+        path_tolerance=0.1,  # type: float
+        resample_dt=0.01,  # type: float
+        min_angle_change=0.001,  # type: float
         joint_torque_limits=None,  # type: Optional[List[float]]
         accel_limit_decrement_factor=0.1,  # type: float
-        try_torque_stuffing=True,  # type: bool
+        max_iterations=10,  # type: int
     ):
         # type: (...) -> RobotTrajectory
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)
         ser_traj_in = conversions.msg_to_string(traj_in)
-        ser_gravity_vector = conversions.msg_to_string(gravity_vector)
-        ser_external_link_wrenches = [
-            conversions.msg_to_string(w) for w in external_link_wrenches or []
-        ]
-        if joint_torque_limits is None:
-            joint_torque_limits = []
+
+        ser_gravity_vector = None
+        if gravity_vector is not None:
+            ser_gravity_vector = conversions.msg_to_string(gravity_vector)
+
+        ser_external_link_wrenches = None
+        if external_link_wrenches is not None:
+            ser_external_link_wrenches = [
+                conversions.msg_to_string(w) for w in external_link_wrenches
+            ]
+
         ser_traj_out = self._g.retime_trajectory(
             ser_ref_state_in,
             ser_traj_in,
             velocity_scaling_factor,
             acceleration_scaling_factor,
             algorithm,
+            try_torque_stuffing,
             ser_gravity_vector,
             ser_external_link_wrenches,
+            path_tolerance,
+            resample_dt,
+            min_angle_change,
             joint_torque_limits,
             accel_limit_decrement_factor,
-            try_torque_stuffing,
+            max_iterations,
         )
         traj_out = RobotTrajectory()
         traj_out.deserialize(ser_traj_out)

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -747,6 +747,50 @@ class MoveGroupCommander(object):
         max_iterations=None,  # type: Optional[int]
     ):
         # type: (...) -> RobotTrajectory
+        """
+        Retime a RobotTrajectory message using one of several time parameterization
+        algorithms.
+
+        Args:
+            ref_state_in: Reference state of the robot
+            traj_in: Trajectory to be retimed
+            velocity_scaling_factor: Factor to scale maximum joint
+                velocities (0.0, 1.0]. Default: 1.0
+            acceleration_scaling_factor: Factor to scale maximum joint
+                accelerations (0.0, 1.0]. Default: 1.0
+            algorithm: Time parameterization algorithm.
+                - "iterative_time_parameterization" (IPTP) (default)
+                - "iterative_spline_parameterization" (ISP)
+                - "time_optimal_trajectory_generation" (TOTG)
+                - "iterative_torque_limit_parameterization" (ITLP)
+            try_torque_stuffing: Whether to compute and store joint torques
+                in the returned trajectory. Default: True
+            gravity_vector: Gravity w.r.t. robot model base frame;
+                zero gravity if not specified. Default: None
+            external_link_wrenches: External forces on links; the number of
+                wrenches must match the number of links in the robot model.
+                Zero external wrenches if not specified. Default: None
+            path_tolerance: Path tolerance (rad or m) for TOTG/ITLP; if not
+                specified, a default value is used. See TOTG/ITLP docs for
+                details and default.
+            resample_dt: Resampling interval (s) for TOTG/ITLP; if not
+                specified, a default value is used. See TOTG/ITLP docs for
+                details and default.
+            min_angle_change: Minimum angle change (rad) for TOTG/ITLP;
+                if not specified, a default value is used. See TOTG/ITLP docs
+                for details and default.
+            joint_torque_limits: Joint torque limits (Nm) for ITLP;
+                Required for ITLP!
+            accel_limit_decrement_factor: Acceleration limit decrement factor
+                for ITLP; if not specified, a default value is used. See
+                ITLP docs for details and default.
+            max_iterations: Maximum number of iterations for ITLP; if not
+                specified, a default value is used. See ITLP docs for details
+                and default.
+
+        Returns:
+            Trajectory with time parameterization applied.
+        """
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)
         ser_traj_in = conversions.msg_to_string(traj_in)
 

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -739,12 +739,12 @@ class MoveGroupCommander(object):
         try_torque_stuffing=True,  # type: bool
         gravity_vector=None,  # type: Optional[Vector3]
         external_link_wrenches=None,  # type: Optional[List[Wrench]]
-        path_tolerance=0.1,  # type: float
-        resample_dt=0.01,  # type: float
-        min_angle_change=0.001,  # type: float
+        path_tolerance=None,  # type: Optional[float]
+        resample_dt=None,  # type: Optional[float]
+        min_angle_change=None,  # type: Optional[float]
         joint_torque_limits=None,  # type: Optional[List[float]]
-        accel_limit_decrement_factor=0.1,  # type: float
-        max_iterations=10,  # type: int
+        accel_limit_decrement_factor=None,  # type: Optional[float]
+        max_iterations=None,  # type: Optional[int]
     ):
         # type: (...) -> RobotTrajectory
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
@@ -37,14 +37,16 @@
 #pragma once
 
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+#include <boost/optional.hpp>
 
 namespace trajectory_processing
 {
 class IterativeTorqueLimitParameterization
 {
 public:
-  IterativeTorqueLimitParameterization(const double path_tolerance = 0.1, const double resample_dt = 0.01,
-                                       const double min_angle_change = 0.001);
+  IterativeTorqueLimitParameterization(boost::optional<double> path_tolerance = boost::none,
+                                       boost::optional<double> resample_dt = boost::none,
+                                       boost::optional<double> min_angle_change = boost::none);
 
   /**
    * \brief Compute a trajectory with waypoints spaced equally in time (according to resample_dt_).
@@ -60,21 +62,22 @@ public:
    * \param joint_torque_limits Torque limits for each joint in N*m. All should be >0.
    * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
    * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
-   * \param accel_limit_decrement_factor Must be in the range [0.01-0.2]. Default: 0.1.
-   *    This affects how fast acceleration limits are decreased while searching for a solution.
-   *    Time-optimality of the output is accurate to approximately 100*accel_limit_decrement_factor %.
-   *    For example, if accel_limit_decrement_factor is 0.1, the output should be within 10% of time-optimal.
-   * \param max_iterations Maximum number of times to do the TOTG->torque check->accel change loop. Default: 10.
+   * \param accel_limit_decrement_factor Must be in the range [0.01-0.2]. If not specified, default is 0.1.
+   *   This affects how fast acceleration limits are decreased while searching for a solution.
+   *   Time-optimality of the output is accurate to approximately 100*accel_limit_decrement_factor %.
+   *   For example, if accel_limit_decrement_factor is 0.1, the output should be within 10% of time-optimal.
+   * \param max_iterations Maximum number of times to do the TOTG->torque check->accel change loop.
+   *   If not specified, default is 10.
    * \param reset_traj_after_max_iterations Whether to reset `trajectory` to its initial state when more than
-   *   `max_iterations` iterations is needed to get all torques under their limits. Default: False, i.e. use the
-   *   result of the last iteration.
+   *   `max_iterations` iterations is needed to get all torques under their limits. If not specified, default is false.
    */
   bool computeTimeStampsWithTorqueLimits(
       robot_trajectory::RobotTrajectory& trajectory, const geometry_msgs::Vector3& gravity_vector,
       const std::vector<geometry_msgs::Wrench>& external_link_wrenches, const std::vector<double>& joint_torque_limits,
       const double max_velocity_scaling_factor, const double max_acceleration_scaling_factor,
-      const double accel_limit_decrement_factor = 0.1, const size_t max_iterations = 10,
-      const bool reset_trajectory_after_max_iterations = false) const;
+      boost::optional<double> accel_limit_decrement_factor = boost::none,
+      boost::optional<size_t> max_iterations = boost::none,
+      boost::optional<bool> reset_trajectory_after_max_iterations = boost::none) const;
 
 private:
   TimeOptimalTrajectoryGeneration totg_;

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
@@ -43,7 +43,7 @@ namespace trajectory_processing
 class IterativeTorqueLimitParameterization
 {
 public:
-  IterativeTorqueLimitParameterization(const double path_tolerance = 0.1, const double resample_dt = 0.1,
+  IterativeTorqueLimitParameterization(const double path_tolerance = 0.1, const double resample_dt = 0.01,
                                        const double min_angle_change = 0.001);
 
   /**
@@ -55,27 +55,25 @@ public:
    * meters for prismatic joints.
    * \param[in,out] trajectory A path which needs time-parameterization. It's OK if this path has already been
    * time-parameterized; this function will re-time-parameterize it.
-   * \param gravity_vector For example, (0, 0, -9.81). Units are m/s^2
+   * \param gravity_vector W.r.t. the robot's base frame. Units are m/s^2
    * \param external_link_wrenches Externally-applied wrenches on each link. TODO(andyz): what frame is this in?
-   * \param joint_torque_limits Torque limits for each joint in N*m. All should be >0. TODO(cj): Populate from robot
-   *   description.
-   * \param accel_limit_decrement_factor Typically in the range [0.01-0.1].
-   * This affects how fast acceleration limits are decreased while searching for a solution. Time-optimality
-   * of the output is accurate to approximately 100*accel_limit_decrement_factor %.
-   * For example, if accel_limit_decrement_factor is 0.1, the output should be within 10% of time-optimal.
+   * \param joint_torque_limits Torque limits for each joint in N*m. All should be >0.
    * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
    * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param accel_limit_decrement_factor Must be in the range [0.01-0.2]. Default: 0.1.
+   *    This affects how fast acceleration limits are decreased while searching for a solution.
+   *    Time-optimality of the output is accurate to approximately 100*accel_limit_decrement_factor %.
+   *    For example, if accel_limit_decrement_factor is 0.1, the output should be within 10% of time-optimal.
    * \param max_iterations Maximum number of times to do the TOTG->torque check->accel change loop. Default: 10.
    * \param reset_traj_after_max_iterations Whether to reset `trajectory` to its initial state when more than
-   *   `max_iterations` iterations is needed to get all torques under their limits. Default: False, i.e. return the
+   *   `max_iterations` iterations is needed to get all torques under their limits. Default: False, i.e. use the
    *   result of the last iteration.
    */
   bool computeTimeStampsWithTorqueLimits(
       robot_trajectory::RobotTrajectory& trajectory, const geometry_msgs::Vector3& gravity_vector,
       const std::vector<geometry_msgs::Wrench>& external_link_wrenches, const std::vector<double>& joint_torque_limits,
-      double accel_limit_decrement_factor, const std::unordered_map<std::string, double>& velocity_limits,
-      const std::unordered_map<std::string, double>& acceleration_limits, const double max_velocity_scaling_factor,
-      const double max_acceleration_scaling_factor, const size_t max_iterations = 10,
+      const double max_velocity_scaling_factor, const double max_acceleration_scaling_factor,
+      const double accel_limit_decrement_factor = 0.1, const size_t max_iterations = 10,
       const bool reset_trajectory_after_max_iterations = false) const;
 
 private:

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
@@ -44,6 +44,7 @@ namespace trajectory_processing
 class IterativeTorqueLimitParameterization
 {
 public:
+  // TimeOptimalTrajectoryGeneration defaults will be used for any parameters that are not specified.
   IterativeTorqueLimitParameterization(boost::optional<double> path_tolerance = boost::none,
                                        boost::optional<double> resample_dt = boost::none,
                                        boost::optional<double> min_angle_change = boost::none);
@@ -62,9 +63,9 @@ public:
    * \param joint_torque_limits Torque limits for each joint in N*m. All should be >0.
    * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
    * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
-   * \param accel_limit_decrement_factor Must be in the range [0.01-0.2]. If not specified, default is 0.1.
+   * \param accel_limit_decrement_factor Must be in the range [0.01, 0.2]. If not specified, default is 0.1.
    *   This affects how fast acceleration limits are decreased while searching for a solution.
-   *   Time-optimality of the output is accurate to approximately 100*accel_limit_decrement_factor %.
+   *   Time-optimality of the output is accurate to approximately (100*accel_limit_decrement_factor)%.
    *   For example, if accel_limit_decrement_factor is 0.1, the output should be within 10% of time-optimal.
    * \param max_iterations Maximum number of times to do the TOTG->torque check->accel change loop.
    *   If not specified, default is 10.

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -166,7 +166,7 @@ MOVEIT_CLASS_FORWARD(TimeOptimalTrajectoryGeneration);
 class TimeOptimalTrajectoryGeneration : public TimeParameterization
 {
 public:
-  TimeOptimalTrajectoryGeneration(const double path_tolerance = 0.1, const double resample_dt = 0.1,
+  TimeOptimalTrajectoryGeneration(const double path_tolerance = 0.1, const double resample_dt = 0.01,
                                   const double min_angle_change = 0.001);
 
   /**

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -167,9 +167,9 @@ MOVEIT_CLASS_FORWARD(TimeOptimalTrajectoryGeneration);
 class TimeOptimalTrajectoryGeneration : public TimeParameterization
 {
 public:
-  TimeOptimalTrajectoryGeneration(boost::optional<double> path_tolerance = boost::none,
-                                  boost::optional<double> resample_dt = boost::none,
-                                  boost::optional<double> min_angle_change = boost::none);
+  TimeOptimalTrajectoryGeneration(boost::optional<double> path_tolerance = boost::none,  // default: 0.1 (rad or m)
+                                  boost::optional<double> resample_dt = boost::none,  // default: 0.01 (s)
+                                  boost::optional<double> min_angle_change = boost::none);  // default: 0.001 (rad)
 
   /**
    * \brief Compute a trajectory with waypoints spaced equally in time (according to resample_dt_).

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -39,10 +39,11 @@
 #ifndef MOVEIT_TRAJECTORY_PROCESSING_TIME_OPTIMAL_TRAJECTORY_GENERATION_H
 #define MOVEIT_TRAJECTORY_PROCESSING_TIME_OPTIMAL_TRAJECTORY_GENERATION_H
 
-#include <Eigen/Core>
-#include <list>
 #include <moveit/robot_trajectory/robot_trajectory.h>
 #include <moveit/trajectory_processing/time_parameterization.h>
+#include <boost/optional.hpp>
+#include <Eigen/Core>
+#include <list>
 #include <unordered_map>
 
 namespace trajectory_processing
@@ -166,8 +167,9 @@ MOVEIT_CLASS_FORWARD(TimeOptimalTrajectoryGeneration);
 class TimeOptimalTrajectoryGeneration : public TimeParameterization
 {
 public:
-  TimeOptimalTrajectoryGeneration(const double path_tolerance = 0.1, const double resample_dt = 0.01,
-                                  const double min_angle_change = 0.001);
+  TimeOptimalTrajectoryGeneration(boost::optional<double> path_tolerance = boost::none,
+                                  boost::optional<double> resample_dt = boost::none,
+                                  boost::optional<double> min_angle_change = boost::none);
 
   /**
    * \brief Compute a trajectory with waypoints spaced equally in time (according to resample_dt_).

--- a/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
@@ -65,7 +65,7 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
 
   const double accel_decrement_factor = accel_limit_decrement_factor.get_value_or(0.1);
   const size_t max_iter = max_iterations.get_value_or(10);
-  const bool reset_trajectory = reset_trajectory_after_max_iterations.get_value_or(false);
+  const bool reset_trajectory_after_max_iter = reset_trajectory_after_max_iterations.get_value_or(false);
 
   if (trajectory.empty())
     return true;
@@ -110,11 +110,12 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
 
   // TODO(cj): Factor out limit resolution; common/duplicated in TOTG as well.
   std::unordered_map<std::string, double> velocity_limits;
-  std::unordered_map<std::string, double> acceleration_limits;
+  std::unordered_map<std::string, double> mutable_acceleration_limits;
 
   for (size_t j = 0; j < num_joints; ++j)
   {
     const std::string& name = joint_names[j];
+    // Each element in `joint_bounds` is a pointer to a Bounds object, which masks vector<VariableBounds>.
     const robot_model::JointModel::Bounds* bounds_ptr = joint_bounds[j];
     if (bounds_ptr->size() != 1)
     {
@@ -123,50 +124,36 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     }
     const moveit::core::VariableBounds vb = (*bounds_ptr)[0];
 
-    // Resolve velocity limit: Fill in if not already provided.
-    auto it = velocity_limits.find(name);
-    if (it == velocity_limits.end())
+    // Resolve velocity limit
+    if (vb.velocity_bounded_)
     {
-      if (vb.velocity_bounded_)
+      double limit = std::min(std::fabs(vb.max_velocity_), std::fabs(vb.min_velocity_));
+      if (!validate_limit("velocity", limit, name))
       {
-        double limit = std::min(std::fabs(vb.max_velocity_), std::fabs(vb.min_velocity_));
-        if (!validate_limit("velocity", limit, name))
-          return false;
-        velocity_limits[name] = limit;
-      }
-      else
-      {
-        velocity_limits[name] = DEFAULT_VELOCITY_LIMIT;
-        ROS_WARN_ONCE_NAMED(LOGNAME,
-          "No velocity limits defined for '%s'! Define them in the URDF.", name.c_str());
-      }
-    }
-    else {
-      if (!validate_limit("velocity", it->second, name))
         return false;
+      }
+      velocity_limits[name] = limit;
+    }
+    else
+    {
+      velocity_limits[name] = DEFAULT_VELOCITY_LIMIT;
+      ROS_WARN_ONCE_NAMED(LOGNAME, "No velocity limits defined for '%s'! Define them in the URDF.", name.c_str());
     }
 
-    // Resolve acceleration limit: Fill in if not already provided.
-    it = acceleration_limits.find(name);
-    if (it == acceleration_limits.end())
+    // Resolve acceleration limit
+    if (vb.acceleration_bounded_)
     {
-      if (vb.acceleration_bounded_)
+      double limit = std::min(std::fabs(vb.max_acceleration_), std::fabs(vb.min_acceleration_));
+      if (!validate_limit("acceleration", limit, name))
       {
-        double limit = std::min(std::fabs(vb.max_acceleration_), std::fabs(vb.min_acceleration_));
-        if (!validate_limit("acceleration", limit, name))
-          return false;
-        acceleration_limits[name] = limit;
-      }
-      else
-      {
-        acceleration_limits[name] = DEFAULT_ACCELERATION_LIMIT;
-        ROS_WARN_ONCE_NAMED(LOGNAME,
-          "No acceleration limits defined for '%s'! Define them in the URDF.", name.c_str());
-      }
-    }
-    else {
-      if (!validate_limit("acceleration", it->second, name))
         return false;
+      }
+      mutable_acceleration_limits[name] = limit;
+    }
+    else
+    {
+      mutable_acceleration_limits[name] = DEFAULT_ACCELERATION_LIMIT;
+      ROS_WARN_ONCE_NAMED(LOGNAME, "No acceleration limits defined for '%s'! Define them in the URDF.", name.c_str());
     }
   }
 
@@ -185,9 +172,10 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     ++num_iterations;
     iteration_needed = false;
 
-    // TOTG is always run on the same trajectory; `acceleration_limits` is the only thing changing across iterations.
+    // TOTG is always run on the same trajectory;
+    // `mutable_acceleration_limits` is the only thing changing across iterations.
     trajectory.setRobotTrajectoryMsg(initial_state, original_traj);
-    totg_.computeTimeStamps(trajectory, velocity_limits, acceleration_limits, max_velocity_scaling_factor,
+    totg_.computeTimeStamps(trajectory, velocity_limits, mutable_acceleration_limits, max_velocity_scaling_factor,
                             max_acceleration_scaling_factor);
 
     std::vector<double> joint_positions(dof);
@@ -238,11 +226,11 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
           }
           if (std::fabs(joint_torques.at(joint_idx)) < std::fabs(previous_torque))
           {
-            acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 + accel_decrement_factor);
+            mutable_acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 + accel_decrement_factor);
           }
           else
           {
-            acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 - accel_decrement_factor);
+            mutable_acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 - accel_decrement_factor);
           }
 
           iteration_needed = true;
@@ -258,7 +246,7 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
 
   if (num_iterations >= max_iter && iteration_needed)
   {
-    if (reset_trajectory)
+    if (reset_trajectory_after_max_iter)
     {
       ROS_WARN_STREAM_NAMED(LOGNAME, "ITLP needs more than max_iterations; resetting trajectory");
       trajectory.setRobotTrajectoryMsg(initial_state, original_traj);

--- a/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
@@ -55,9 +55,8 @@ IterativeTorqueLimitParameterization::IterativeTorqueLimitParameterization(const
 bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     robot_trajectory::RobotTrajectory& trajectory, const geometry_msgs::Vector3& gravity_vector,
     const std::vector<geometry_msgs::Wrench>& external_link_wrenches, const std::vector<double>& joint_torque_limits,
-    double accel_limit_decrement_factor, const std::unordered_map<std::string, double>& velocity_limits,
-    const std::unordered_map<std::string, double>& acceleration_limits, const double max_velocity_scaling_factor,
-    const double max_acceleration_scaling_factor, const size_t max_iterations,
+    const double max_velocity_scaling_factor, const double max_acceleration_scaling_factor,
+    const double accel_limit_decrement_factor, const size_t max_iterations,
     const bool reset_trajectory_after_max_iterations) const
 {
   // 1. Call computeTimeStamps() to time-parameterize the trajectory with given vel/accel limits.
@@ -74,7 +73,7 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     return false;
   }
 
-  size_t dof = group->getActiveJointModels().size();
+  const size_t dof = group->getActiveJointModels().size();
 
   if (joint_torque_limits.size() != dof)
   {
@@ -89,13 +88,6 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     ROS_ERROR_NAMED(LOGNAME, "The accel_limit_decrement_factor is outside the typical range [0.01, 0.2]");
     return false;
   }
-
-  /* Create a mutable copy of `velocity_limits` and `acceleration_limits`;
-   * fill them in from the robot description if they are empty.
-   * TODO(cj): Factor out limit resolution; common/duplicated in TOTG as well.
-   */
-  std::unordered_map<std::string, double> mutable_vel_limits = velocity_limits;
-  std::unordered_map<std::string, double> mutable_accel_limits = acceleration_limits;
 
   // Lambda for validating limits
   auto validate_limit = [](const char* type, double value, const std::string& name) {
@@ -112,10 +104,13 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
   size_t num_joints = joint_names.size();
   const robot_model::JointBoundsVector joint_bounds = group->getActiveJointModelsBounds();
 
+  // TODO(cj): Factor out limit resolution; common/duplicated in TOTG as well.
+  std::unordered_map<std::string, double> velocity_limits;
+  std::unordered_map<std::string, double> acceleration_limits;
+
   for (size_t j = 0; j < num_joints; ++j)
   {
     const std::string& name = joint_names[j];
-    // Each element in joint_bounds is a pointer to a Bounds (i.e., vector<VariableBounds>)
     const robot_model::JointModel::Bounds* bounds_ptr = joint_bounds[j];
     if (bounds_ptr->size() != 1)
     {
@@ -125,21 +120,21 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     const moveit::core::VariableBounds vb = (*bounds_ptr)[0];
 
     // Resolve velocity limit: Fill in if not already provided.
-    auto it = mutable_vel_limits.find(name);
-    if (it == mutable_vel_limits.end())
+    auto it = velocity_limits.find(name);
+    if (it == velocity_limits.end())
     {
       if (vb.velocity_bounded_)
       {
         double limit = std::min(std::fabs(vb.max_velocity_), std::fabs(vb.min_velocity_));
         if (!validate_limit("velocity", limit, name))
           return false;
-        mutable_vel_limits[name] = limit;
+        velocity_limits[name] = limit;
       }
       else
       {
-        mutable_vel_limits[name] = DEFAULT_VELOCITY_LIMIT;
+        velocity_limits[name] = DEFAULT_VELOCITY_LIMIT;
         ROS_WARN_ONCE_NAMED(LOGNAME,
-          "No velocity limits defined for '%s'! Define them in URDF or joint_limits.yaml", name.c_str());
+          "No velocity limits defined for '%s'! Define them in the URDF.", name.c_str());
       }
     }
     else {
@@ -148,21 +143,21 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     }
 
     // Resolve acceleration limit: Fill in if not already provided.
-    it = mutable_accel_limits.find(name);
-    if (it == mutable_accel_limits.end())
+    it = acceleration_limits.find(name);
+    if (it == acceleration_limits.end())
     {
       if (vb.acceleration_bounded_)
       {
         double limit = std::min(std::fabs(vb.max_acceleration_), std::fabs(vb.min_acceleration_));
         if (!validate_limit("acceleration", limit, name))
           return false;
-        mutable_accel_limits[name] = limit;
+        acceleration_limits[name] = limit;
       }
       else
       {
-        mutable_accel_limits[name] = DEFAULT_ACCELERATION_LIMIT;
+        acceleration_limits[name] = DEFAULT_ACCELERATION_LIMIT;
         ROS_WARN_ONCE_NAMED(LOGNAME,
-          "No acceleration limits defined for '%s'! Define them in joint_limits.yaml", name.c_str());
+          "No acceleration limits defined for '%s'! Define them in the URDF.", name.c_str());
       }
     }
     else {
@@ -186,9 +181,9 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     ++num_iterations;
     iteration_needed = false;
 
-    // TOTG is always run on the same trajectory;`mutable_accel_limits` is the only thing changing across iterations.
+    // TOTG is always run on the same trajectory; `acceleration_limits` is the only thing changing across iterations.
     trajectory.setRobotTrajectoryMsg(initial_state, original_traj);
-    totg_.computeTimeStamps(trajectory, mutable_vel_limits, mutable_accel_limits, max_velocity_scaling_factor,
+    totg_.computeTimeStamps(trajectory, velocity_limits, acceleration_limits, max_velocity_scaling_factor,
                             max_acceleration_scaling_factor);
 
     std::vector<double> joint_positions(dof);
@@ -239,11 +234,11 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
           }
           if (std::fabs(joint_torques.at(joint_idx)) < std::fabs(previous_torque))
           {
-            mutable_accel_limits.at(joint_models.at(joint_idx)->getName()) *= (1 + accel_limit_decrement_factor);
+            acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 + accel_limit_decrement_factor);
           }
           else
           {
-            mutable_accel_limits.at(joint_models.at(joint_idx)->getName()) *= (1 - accel_limit_decrement_factor);
+            acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 - accel_limit_decrement_factor);
           }
 
           iteration_needed = true;

--- a/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
@@ -45,9 +45,9 @@ constexpr double DEFAULT_VELOCITY_LIMIT = 1.0;
 constexpr double DEFAULT_ACCELERATION_LIMIT = 1.0;
 }
 
-IterativeTorqueLimitParameterization::IterativeTorqueLimitParameterization(const double path_tolerance,
-                                                                           const double resample_dt,
-                                                                           const double min_angle_change)
+IterativeTorqueLimitParameterization::IterativeTorqueLimitParameterization(boost::optional<double> path_tolerance,
+                                                                           boost::optional<double> resample_dt,
+                                                                           boost::optional<double> min_angle_change)
   : totg_(path_tolerance, resample_dt, min_angle_change)
 {
 }
@@ -56,12 +56,16 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     robot_trajectory::RobotTrajectory& trajectory, const geometry_msgs::Vector3& gravity_vector,
     const std::vector<geometry_msgs::Wrench>& external_link_wrenches, const std::vector<double>& joint_torque_limits,
     const double max_velocity_scaling_factor, const double max_acceleration_scaling_factor,
-    const double accel_limit_decrement_factor, const size_t max_iterations,
-    const bool reset_trajectory_after_max_iterations) const
+    boost::optional<double> accel_limit_decrement_factor, boost::optional<size_t> max_iterations,
+    boost::optional<bool> reset_trajectory_after_max_iterations) const
 {
   // 1. Call computeTimeStamps() to time-parameterize the trajectory with given vel/accel limits.
   // 2. Run forward dynamics to check if torque limits are violated at any waypoint.
   // 3. If a torque limit was violated, decrease the acceleration limit for that joint and go back to Step 1.
+
+  const double accel_decrement_factor = accel_limit_decrement_factor.get_value_or(0.1);
+  const size_t max_iter = max_iterations.get_value_or(10);
+  const bool reset_trajectory = reset_trajectory_after_max_iterations.get_value_or(false);
 
   if (trajectory.empty())
     return true;
@@ -83,7 +87,7 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     return false;
   }
 
-  if (accel_limit_decrement_factor < 0.01 || accel_limit_decrement_factor > 0.2)
+  if (accel_decrement_factor < 0.01 || accel_decrement_factor > 0.2)
   {
     ROS_ERROR_NAMED(LOGNAME, "The accel_limit_decrement_factor is outside the typical range [0.01, 0.2]");
     return false;
@@ -176,7 +180,7 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
   bool iteration_needed = true;
   size_t num_iterations = 0;
 
-  while (iteration_needed && num_iterations < max_iterations)
+  while (iteration_needed && num_iterations < max_iter)
   {
     ++num_iterations;
     iteration_needed = false;
@@ -225,7 +229,7 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
 
           // Check if decreasing acceleration of this joint actually decreases joint torque. Else, increase acceleration.
           double previous_torque = joint_torques.at(joint_idx);
-          joint_accelerations.at(joint_idx) *= (1 + accel_limit_decrement_factor);
+          joint_accelerations.at(joint_idx) *= (1 + accel_decrement_factor);
           if (!dynamics_solver.getTorques(joint_positions, joint_velocities, joint_accelerations,
                                           external_link_wrenches, joint_torques))
           {
@@ -234,11 +238,11 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
           }
           if (std::fabs(joint_torques.at(joint_idx)) < std::fabs(previous_torque))
           {
-            acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 + accel_limit_decrement_factor);
+            acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 + accel_decrement_factor);
           }
           else
           {
-            acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 - accel_limit_decrement_factor);
+            acceleration_limits.at(joint_models.at(joint_idx)->getName()) *= (1 - accel_decrement_factor);
           }
 
           iteration_needed = true;
@@ -250,11 +254,11 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
         break;
       }
     }  // for each waypoint
-  }  // while (iteration_needed && num_iterations < max_iterations)
+      }  // while (iteration_needed && num_iterations < max_iter)
 
-  if (num_iterations >= max_iterations && iteration_needed)
+  if (num_iterations >= max_iter && iteration_needed)
   {
-    if (reset_trajectory_after_max_iterations)
+    if (reset_trajectory)
     {
       ROS_WARN_STREAM_NAMED(LOGNAME, "ITLP needs more than max_iterations; resetting trajectory");
       trajectory.setRobotTrajectoryMsg(initial_state, original_traj);

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -864,9 +864,11 @@ Eigen::VectorXd Trajectory::getAcceleration(double time) const
   return path_acc;
 }
 
-TimeOptimalTrajectoryGeneration::TimeOptimalTrajectoryGeneration(const double path_tolerance, const double resample_dt,
-                                                                 const double min_angle_change)
-  : path_tolerance_(path_tolerance), resample_dt_(resample_dt), min_angle_change_(min_angle_change)
+TimeOptimalTrajectoryGeneration::TimeOptimalTrajectoryGeneration(boost::optional<double> path_tolerance,
+                                                                 boost::optional<double> resample_dt,
+                                                                 boost::optional<double> min_angle_change)
+  : path_tolerance_(path_tolerance.get_value_or(0.1)), resample_dt_(resample_dt.get_value_or(0.01)),
+    min_angle_change_(min_angle_change.get_value_or(0.001))
 {
 }
 

--- a/moveit_core/trajectory_processing/test/test_iterative_torque_limit_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_iterative_torque_limit_parameterization.cpp
@@ -66,6 +66,15 @@ TEST(time_optimal_trajectory_generation, test_totg_with_torque_limits)
   auto robot_model = std::make_shared<moveit::core::RobotModel>(urdf_model, srdf_model);
   ASSERT_TRUE((bool)robot_model) << "Failed to load robot model";
 
+  // Set velocity and acceleration bounds for joint_a
+  moveit_msgs::JointLimits joint_limits;
+  joint_limits.joint_name = "joint_a";
+  joint_limits.has_velocity_limits = true;
+  joint_limits.max_velocity = 3.0;
+  joint_limits.has_acceleration_limits = true;
+  joint_limits.max_acceleration = 3.0;
+  robot_model->getJointModel("joint_a")->setVariableBounds(std::vector<moveit_msgs::JointLimits>{joint_limits});
+
   auto group = robot_model->getJointModelGroup("single_dof_group");
   ASSERT_TRUE((bool)group) << "Failed to load joint model group ";
   moveit::core::RobotState waypoint_state(robot_model);
@@ -86,8 +95,6 @@ TEST(time_optimal_trajectory_generation, test_totg_with_torque_limits)
   }();
   const std::vector<double> joint_torque_limits{ 250 };  // in N*m
   const double accel_limit_decrement_factor = 0.1;
-  const std::unordered_map<std::string, double> velocity_limits = { { "joint_a", 3 } };
-  const std::unordered_map<std::string, double> acceleration_limits = { { "joint_a", 3 } };
 
   trajectory_processing::IterativeTorqueLimitParameterization totg(0.1 /* path tolerance */, 0.01 /* resample dt */,
                                                                    0.001 /* min angle change */);
@@ -108,8 +115,8 @@ TEST(time_optimal_trajectory_generation, test_totg_with_torque_limits)
 
   bool totg_success =
       totg.computeTimeStampsWithTorqueLimits(trajectory, gravity_vector, external_link_wrenches, joint_torque_limits,
-                                             accel_limit_decrement_factor, velocity_limits, acceleration_limits,
-                                             1.0 /* vel scaling */, 1.0 /* accel scaling */);
+                                             1.0 /* vel scaling */, 1.0 /* accel scaling */,
+                                             accel_limit_decrement_factor);
   ASSERT_TRUE(totg_success) << "Failed to compute timestamps";
   double first_duration = trajectory.getDuration();
 
@@ -117,8 +124,8 @@ TEST(time_optimal_trajectory_generation, test_totg_with_torque_limits)
   const std::vector<double> lower_torque_limits{ 1 };  // in N*m
   totg_success =
       totg.computeTimeStampsWithTorqueLimits(trajectory, gravity_vector, external_link_wrenches, lower_torque_limits,
-                                             accel_limit_decrement_factor, velocity_limits, acceleration_limits,
-                                             1.0 /* accel scaling */, 1.0 /* vel scaling */);
+                                             1.0 /* vel scaling */, 1.0 /* accel scaling */,
+                                             accel_limit_decrement_factor);
   ASSERT_TRUE(totg_success) << "Failed to compute timestamps";
   double second_duration = trajectory.getDuration();
   EXPECT_GT(second_duration, first_duration) << "The second time parameterization should result in a longer duration";

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -559,18 +559,18 @@ public:
   }
 
   /**
-   * @brief Computes joint torques for each waypoint in a RobotTrajectory message
-   * and stores them in the effort field.
+   * \brief Computes joint torques for each waypoint in a RobotTrajectory message
+   *   and stores them in the effort field.
    *
-   * @param trajectory_msg The trajectory to compute torques for (the effort field will be overwritten)
-   * @param robot_model The robot model to use for dynamics calculations.
-   * @param group_name Name of the joint group to compute torques for.
-   * @param gravity_vector The gravity vector to use in dynamics calculations.
-   * @param external_link_wrenches External wrenches (force/torque) acting on each link.
+   * \param[in,out] trajectory_msg The trajectory to compute torques for (the effort field will be overwritten)
+   * \param robot_model The robot model to use for dynamics calculations.
+   * \param group_name Name of the joint group to compute torques for.
+   * \param gravity_vector The gravity vector to use in dynamics calculations.
+   * \param external_link_wrenches External wrenches (force/torque) acting on each link.
    *
-   * @note No input validation is performed -- recommend calling in a try/catch.
-   * @note Assumes the joint order in trajectory_msg.joint_trajectory matches the
-   * active joint order in the robot model group.
+   * \note No input validation is performed -- recommend calling in a try/catch.
+   * \note Assumes the joint order in trajectory_msg.joint_trajectory matches the
+   *   active joint order in the robot model group.
    * TODO(cj): Provide a binding and expose this to MoveGroupInterface.
    */
   void stuffTorquesIntoRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajectory_msg,
@@ -593,31 +593,36 @@ public:
   }
 
   /**
-   * @brief Retime a RobotTrajectory message using one of several time parameterization algorithms.
+   * \brief Retime a RobotTrajectory message using one of several time parameterization algorithms.
    *
-   * @param ref_state_str Serialized RobotState message representing the reference state
-   * @param traj_str Serialized RobotTrajectory message to be retimed
-   * @param velocity_scaling_factor Factor to scale maximum joint velocities (0.0-1.0)
-   * @param acceleration_scaling_factor Factor to scale maximum joint accelerations (0.0-1.0)
-   * @param algorithm Time parameterization algorithm:
+   * \param ref_state_str Serialized RobotState message representing the reference state
+   * \param traj_str Serialized RobotTrajectory message to be retimed
+   * \param velocity_scaling_factor Factor to scale maximum joint velocities (0.0, 1.0]
+   * \param acceleration_scaling_factor Factor to scale maximum joint accelerations (0.0, 1.0]
+   * \param algorithm Time parameterization algorithm:
    *   - iterative_time_parameterization (IPTP)
    *   - iterative_spline_parameterization (ISP)
    *   - time_optimal_trajectory_generation (TOTG)
    *   - iterative_torque_limit_parameterization (ITLP)
-   * @param try_torque_stuffing Whether to compute and store joint torques in retimed trajectory (default: true)
-   * @param gravity_vector_obj Serialized Vector3 message for gravity w.r.t. robot model base frame;
-   *   If not specified, zero gravity is assumed.
-   * @param external_link_wrenches_obj List of serialized Wrench messages for external forces on links;
-   *   If not specified, zero external wrenches are assumed for all links.
+   * \param try_torque_stuffing Whether to compute and store joint torques in retimed trajectory (default: true)
+   * \param gravity_vector_obj Optional serialized Vector3 message for gravity w.r.t. robot model base frame
+   *   (default: zero gravity)
+   * \param external_link_wrenches_obj Optional list of serialized Wrench messages for external forces on links
+   *   (default: zero external wrenches for all links)
    *   If specified, the number of wrenches must match the number of links in the robot model.
-   * @param path_tolerance_obj See TOTG and ITLP for details
-   * @param resample_dt_obj See TOTG and ITLP for details
-   * @param min_angle_change_obj See TOTG and ITLP for details
-   * @param joint_torque_limits_obj See ITLP for details; required if algorithm is ITLP!
-   * @param accel_limit_decrement_factor_obj See ITLP for details
-   * @param max_iterations_obj See ITLP for details
+   * \param path_tolerance_obj Optional double for TOTG/ITLP path tolerance (rad or m);
+   *   see TOTG/ITLP docs for details and default.
+   * \param resample_dt_obj Optional double for TOTG/ITLP resampling interval (s);
+   *   see TOTG/ITLP docs for details and default.
+   * \param min_angle_change_obj Optional double for TOTG/ITLP minimum angle change (rad);
+   *   see TOTG/ITLP docs for details and default.
+   * \param joint_torque_limits_obj Optional list of doubles for ITLP joint torque limits (Nm); required for ITLP.
+   * \param accel_limit_decrement_factor_obj Optional double for ITLP acceleration limit decrement factor;
+   *   see ITLP docs for details and default.
+   * \param max_iterations_obj Optional int for ITLP maximum number of iterations;
+   *   see ITLP docs for details and default.
    *
-   * @return Serialized RobotTrajectory message with time parameterization applied.
+   * \return Serialized RobotTrajectory message with time parameterization applied.
    */
   py_bindings_tools::ByteString retimeTrajectory(const py_bindings_tools::ByteString& ref_state_str,
                                                  const py_bindings_tools::ByteString& traj_str,

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -51,6 +51,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/buffer.h>
 
+#include <boost/optional.hpp>
 #include <boost/python.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <memory>
@@ -598,23 +599,23 @@ public:
    * @param traj_str Serialized RobotTrajectory message to be retimed
    * @param velocity_scaling_factor Factor to scale maximum joint velocities (0.0-1.0)
    * @param acceleration_scaling_factor Factor to scale maximum joint accelerations (0.0-1.0)
-   * @param algorithm Algorithm to use for time parameterization:
+   * @param algorithm Time parameterization algorithm:
    *   - iterative_time_parameterization (IPTP)
    *   - iterative_spline_parameterization (ISP)
    *   - time_optimal_trajectory_generation (TOTG)
    *   - iterative_torque_limit_parameterization (ITLP)
-   * @param try_torque_stuffing Whether to compute and store joint torques in the retimed trajectory (default: true)
-   * @param gravity_vector_obj Optional serialized Vector3 message for gravity w.r.t. the robot model base frame;
-   *   If not specified (None), then zero gravity is assumed.
-   * @param external_link_wrenches_obj Optional list of serialized Wrench messages for external forces on links;
-   *   If not specified (None), then zero external wrenches are assumed for all links.
-   * @param path_tolerance Path tolerance for TOTG and ITLP (default: 0.1, radians)
-   * @param resample_dt Time step for resampling in TOTG and ITLP (default: 0.01, seconds)
-   * @param min_angle_change Minimum angle change threshold for TOTG and ITLP (default: 0.001, radians)
-   * @param joint_torque_limits_obj Optional list of torque limits (Nm) for each joint (required for ITLP)
-   * @param accel_limit_decrement_factor Factor-of-change in joint acceleration limits between iterations
-   *   of ITLP (default: 0.1)
-   * @param max_iterations Maximum iterations for ITLP algorithm (default: 10)
+   * @param try_torque_stuffing Whether to compute and store joint torques in retimed trajectory (default: true)
+   * @param gravity_vector_obj Serialized Vector3 message for gravity w.r.t. robot model base frame;
+   *   If not specified, zero gravity is assumed.
+   * @param external_link_wrenches_obj List of serialized Wrench messages for external forces on links;
+   *   If not specified, zero external wrenches are assumed for all links.
+   *   If specified, the number of wrenches must match the number of links in the robot model.
+   * @param path_tolerance_obj See TOTG and ITLP for details
+   * @param resample_dt_obj See TOTG and ITLP for details
+   * @param min_angle_change_obj See TOTG and ITLP for details
+   * @param joint_torque_limits_obj See ITLP for details; required if algorithm is ITLP!
+   * @param accel_limit_decrement_factor_obj See ITLP for details
+   * @param max_iterations_obj See ITLP for details
    *
    * @return Serialized RobotTrajectory message with time parameterization applied.
    */
@@ -625,12 +626,12 @@ public:
                                                  bool try_torque_stuffing = true,
                                                  const bp::object& gravity_vector_obj = bp::object(),
                                                  const bp::object& external_link_wrenches_obj = bp::object(),
-                                                 double path_tolerance = 0.1,
-                                                 double resample_dt = 0.01,
-                                                 double min_angle_change = 0.001,
+                                                 const bp::object& path_tolerance_obj = bp::object(),
+                                                 const bp::object& resample_dt_obj = bp::object(),
+                                                 const bp::object& min_angle_change_obj = bp::object(),
                                                  const bp::object& joint_torque_limits_obj = bp::object(),
-                                                 double accel_limit_decrement_factor = 0.1,
-                                                 size_t max_iterations = 10)
+                                                 const bp::object& accel_limit_decrement_factor_obj = bp::object(),
+                                                 const bp::object& max_iterations_obj = bp::object())
   {
     const auto group_name = getName();
     const auto robot_model = getRobotModel();
@@ -673,6 +674,18 @@ public:
     {
       joint_torque_limits = py_bindings_tools::doubleFromList(joint_torque_limits_obj);
     }
+
+    // Convert optional parameters to boost::optional
+    boost::optional<double> path_tolerance = !path_tolerance_obj.is_none() ?
+        boost::optional<double>(bp::extract<double>(path_tolerance_obj)) : boost::none;
+    boost::optional<double> resample_dt = !resample_dt_obj.is_none() ?
+        boost::optional<double>(bp::extract<double>(resample_dt_obj)) : boost::none;
+    boost::optional<double> min_angle_change = !min_angle_change_obj.is_none() ?
+        boost::optional<double>(bp::extract<double>(min_angle_change_obj)) : boost::none;
+    boost::optional<double> accel_limit_decrement_factor = !accel_limit_decrement_factor_obj.is_none() ?
+        boost::optional<double>(bp::extract<double>(accel_limit_decrement_factor_obj)) : boost::none;
+    boost::optional<size_t> max_iterations = !max_iterations_obj.is_none() ?
+        boost::optional<size_t>(bp::extract<size_t>(max_iterations_obj)) : boost::none;
 
     // Release GIL and do the actual retiming.
     {

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -591,15 +591,46 @@ public:
     }
   }
 
+  /**
+   * @brief Retime a RobotTrajectory message using one of several time parameterization algorithms.
+   *
+   * @param ref_state_str Serialized RobotState message representing the reference state
+   * @param traj_str Serialized RobotTrajectory message to be retimed
+   * @param velocity_scaling_factor Factor to scale maximum joint velocities (0.0-1.0)
+   * @param acceleration_scaling_factor Factor to scale maximum joint accelerations (0.0-1.0)
+   * @param algorithm Algorithm to use for time parameterization:
+   *   - iterative_time_parameterization (IPTP)
+   *   - iterative_spline_parameterization (ISP)
+   *   - time_optimal_trajectory_generation (TOTG)
+   *   - iterative_torque_limit_parameterization (ITLP)
+   * @param try_torque_stuffing Whether to compute and store joint torques in the retimed trajectory (default: true)
+   * @param gravity_vector_obj Optional serialized Vector3 message for gravity w.r.t. the robot model base frame;
+   *   If not specified (None), then zero gravity is assumed.
+   * @param external_link_wrenches_obj Optional list of serialized Wrench messages for external forces on links;
+   *   If not specified (None), then zero external wrenches are assumed for all links.
+   * @param path_tolerance Path tolerance for TOTG and ITLP (default: 0.1, radians)
+   * @param resample_dt Time step for resampling in TOTG and ITLP (default: 0.01, seconds)
+   * @param min_angle_change Minimum angle change threshold for TOTG and ITLP (default: 0.001, radians)
+   * @param joint_torque_limits_obj Optional list of torque limits (Nm) for each joint (required for ITLP)
+   * @param accel_limit_decrement_factor Factor-of-change in joint acceleration limits between iterations
+   *   of ITLP (default: 0.1)
+   * @param max_iterations Maximum iterations for ITLP algorithm (default: 10)
+   *
+   * @return Serialized RobotTrajectory message with time parameterization applied.
+   */
   py_bindings_tools::ByteString retimeTrajectory(const py_bindings_tools::ByteString& ref_state_str,
                                                  const py_bindings_tools::ByteString& traj_str,
                                                  double velocity_scaling_factor, double acceleration_scaling_factor,
                                                  const std::string& algorithm,
-                                                 const py_bindings_tools::ByteString& gravity_vector_str,
-                                                 const bp::list& external_link_wrenches_list,
-                                                 const bp::list& joint_torque_limits_list,  // ITLP only
-                                                 double accel_limit_decrement_factor, // ITLP only
-                                                 bool try_torque_stuffing = false)
+                                                 bool try_torque_stuffing = true,
+                                                 const bp::object& gravity_vector_obj = bp::object(),
+                                                 const bp::object& external_link_wrenches_obj = bp::object(),
+                                                 double path_tolerance = 0.1,
+                                                 double resample_dt = 0.01,
+                                                 double min_angle_change = 0.001,
+                                                 const bp::object& joint_torque_limits_obj = bp::object(),
+                                                 double accel_limit_decrement_factor = 0.1,
+                                                 size_t max_iterations = 10)
   {
     const auto group_name = getName();
     const auto robot_model = getRobotModel();
@@ -620,21 +651,28 @@ public:
     py_bindings_tools::deserializeMsg(traj_str, traj_msg);
 
     geometry_msgs::Vector3 gravity_vector;  // Default-constructed as zero vector
-    if (gravity_vector_str != py_bindings_tools::ByteString(""))
+    if (!gravity_vector_obj.is_none())
     {
-      py_bindings_tools::deserializeMsg(gravity_vector_str, gravity_vector);
+      py_bindings_tools::deserializeMsg(bp::extract<py_bindings_tools::ByteString>(gravity_vector_obj),
+                                        gravity_vector);
     }
 
     std::vector<geometry_msgs::Wrench> external_link_wrenches;
-    if (bp::len(external_link_wrenches_list) == 0) {
+    if (!external_link_wrenches_obj.is_none())
+    {
+      convertListToArrayOfWrenches(bp::extract<bp::list>(external_link_wrenches_obj), external_link_wrenches);
+    }
+    if (external_link_wrenches.empty())
+    {
       const robot_model::JointModelGroup* group = ref_state_obj.getJointModelGroup(group_name);
       external_link_wrenches.resize(group ? group->getLinkModelNames().size() : 0);
     }
-    else {
-      convertListToArrayOfWrenches(external_link_wrenches_list, external_link_wrenches);
-    }
 
-    std::vector<double> joint_torque_limits = py_bindings_tools::doubleFromList(joint_torque_limits_list);
+    std::vector<double> joint_torque_limits;
+    if (!joint_torque_limits_obj.is_none())
+    {
+      joint_torque_limits = py_bindings_tools::doubleFromList(joint_torque_limits_obj);
+    }
 
     // Release GIL and do the actual retiming.
     {
@@ -655,16 +693,17 @@ public:
       }
       else if (algorithm == "iterative_torque_limit_parameterization")
       {
-        std::unordered_map<std::string, double> empty_limits;
-        trajectory_processing::IterativeTorqueLimitParameterization time_param;
+        trajectory_processing::IterativeTorqueLimitParameterization time_param(path_tolerance, resample_dt,
+                                                                               min_angle_change);
         time_param.computeTimeStampsWithTorqueLimits(traj_obj, gravity_vector, external_link_wrenches,
-                                                     joint_torque_limits, accel_limit_decrement_factor,
-                                                     empty_limits, empty_limits, velocity_scaling_factor,
-                                                     acceleration_scaling_factor);
+                                                     joint_torque_limits, velocity_scaling_factor,
+                                                     acceleration_scaling_factor, accel_limit_decrement_factor,
+                                                     max_iterations);
       }
       else if (algorithm == "time_optimal_trajectory_generation")
       {
-        trajectory_processing::TimeOptimalTrajectoryGeneration time_param;
+        trajectory_processing::TimeOptimalTrajectoryGeneration time_param(path_tolerance, resample_dt,
+                                                                          min_angle_change);
         time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
       }
       else


### PR DESCRIPTION
Towards SW-2053

Main changes:
1. Set default `resample_dt` for TOTG and ITLP to 0.01 s.
2. Use optional args in `retimeTrajectory()`  for algo-specific params.
* We have to use `boost::optional` because we compile with C++14, and `std::optional` was introduced in C++17 :unamused: 
3. Set a default for ITLP `accel_limit_decrement_factor` of 0.1.
4. Removed the need to pass velocity and acceleration into `computeTimeStampsWithTorqueLimits()`.
5. Set default `try_torque_stuffing` to true.

### Testing
- [x] `moveit` compiles
- [x] `moveit_core` tests pass
- [x] Can use retiming from stack without issue and with different params.