### PR TITLE
:stopwatch: :wrench: Revert TOTG default `resample_dt` from 10 --> 100 ms

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -168,7 +168,7 @@ class TimeOptimalTrajectoryGeneration : public TimeParameterization
 {
 public:
   TimeOptimalTrajectoryGeneration(boost::optional<double> path_tolerance = boost::none,  // default: 0.1 (rad or m)
-                                  boost::optional<double> resample_dt = boost::none,  // default: 0.01 (s)
+                                  boost::optional<double> resample_dt = boost::none,  // default: 0.1 (s)
                                   boost::optional<double> min_angle_change = boost::none);  // default: 0.001 (rad)
 
   /**

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -867,7 +867,7 @@ Eigen::VectorXd Trajectory::getAcceleration(double time) const
 TimeOptimalTrajectoryGeneration::TimeOptimalTrajectoryGeneration(boost::optional<double> path_tolerance,
                                                                  boost::optional<double> resample_dt,
                                                                  boost::optional<double> min_angle_change)
-  : path_tolerance_(path_tolerance.get_value_or(0.1)), resample_dt_(resample_dt.get_value_or(0.01)),
+  : path_tolerance_(path_tolerance.get_value_or(0.1)), resample_dt_(resample_dt.get_value_or(0.1)),
     min_angle_change_(min_angle_change.get_value_or(0.001))
 {
 }


### PR DESCRIPTION
Towards SW-2061

Also applies to ITLP since ITLP just wraps TOTG.

We're pretty sure the 10 ms `resample_dt` was causing erratic motion on for the post_pick_grasp->post_pick_transition motion; see attached ticket.


### Testing
- [x] Works on hw 