### PR TITLE
:weight_lifting: :bug: Fix `dynamics_solver` -- `motor_inertia_torque` variable shadow

### DIFF
--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -226,9 +226,8 @@ bool DynamicsSolver::getTorques(const std::vector<double>& joint_angles, const s
       const moveit::core::JointDynamics& joint_dynamics = joint_model->getJointDynamics();
 
       // Compute reflected motor inertia torque
-      double motor_inertia = joint_dynamics.rotor_inertia + joint_dynamics.reducer_inertia;
-      double motor_inertia_torque = joint_dynamics.gear_ratio * joint_dynamics.gear_ratio *
-                                    motor_inertia * joint_accelerations[i];
+      motor_inertia_torque = joint_dynamics.gear_ratio * joint_dynamics.gear_ratio *
+                             (joint_dynamics.rotor_inertia + joint_dynamics.reducer_inertia) * joint_accelerations[i];
 
       // Compute friction torque
       double velocity = joint_velocities[i];


### PR DESCRIPTION
Completes SW-2062

### Testing
- [x] Planning torques are similar to actual torques
![Screenshot from 2025-07-08 22-04-39](https://github.com/user-attachments/assets/df5fae14-eb36-493f-9c4c-e76f9e36ded2)
