### PR TITLE
:saluting_face: :tada: Add standalone torque stuffing method to MoveGroupCommander

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -736,7 +736,7 @@ class MoveGroupCommander(object):
         velocity_scaling_factor=1.0,  # type: float
         acceleration_scaling_factor=1.0,  # type: float
         algorithm="iterative_time_parameterization",  # type: str
-        try_torque_stuffing=True,  # type: bool
+        try_torque_injection=True,  # type: bool
         gravity_vector=None,  # type: Optional[Vector3]
         external_link_wrenches=None,  # type: Optional[List[Wrench]]
         path_tolerance=None,  # type: Optional[float]
@@ -763,7 +763,7 @@ class MoveGroupCommander(object):
                 - "iterative_spline_parameterization" (ISP)
                 - "time_optimal_trajectory_generation" (TOTG)
                 - "iterative_torque_limit_parameterization" (ITLP)
-            try_torque_stuffing: Whether to compute and store joint torques
+            try_torque_injection: Whether to compute and store joint torques
                 in the returned trajectory. Default: True
             gravity_vector: Gravity w.r.t. robot model base frame;
                 zero gravity if not specified. Default: None
@@ -810,7 +810,7 @@ class MoveGroupCommander(object):
             velocity_scaling_factor,
             acceleration_scaling_factor,
             algorithm,
-            try_torque_stuffing,
+            try_torque_injection,
             ser_gravity_vector,
             ser_external_link_wrenches,
             path_tolerance,
@@ -824,7 +824,7 @@ class MoveGroupCommander(object):
         traj_out.deserialize(ser_traj_out)
         return traj_out
 
-    def stuff_torques_into_trajectory(
+    def inject_trajectory_torques(
         self,
         traj_in,  # type: RobotTrajectory
         gravity_vector=None,  # type: Optional[Vector3]
@@ -844,7 +844,7 @@ class MoveGroupCommander(object):
                 Zero external wrenches if not specified. Default: None
 
         Returns:
-            Trajectory with torques stuffed into the `effort` field.
+            Trajectory with torques injected into the `effort` field.
         """
         ser_traj_in = conversions.msg_to_string(traj_in)
 
@@ -858,7 +858,7 @@ class MoveGroupCommander(object):
                 conversions.msg_to_string(w) for w in external_link_wrenches
             ]
 
-        ser_traj_out = self._g.stuff_torques_into_trajectory(
+        ser_traj_out = self._g.inject_trajectory_torques(
             ser_traj_in,
             ser_gravity_vector,
             ser_external_link_wrenches,

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -824,6 +824,49 @@ class MoveGroupCommander(object):
         traj_out.deserialize(ser_traj_out)
         return traj_out
 
+    def stuff_torques_into_trajectory(
+        self,
+        traj_in,  # type: RobotTrajectory
+        gravity_vector=None,  # type: Optional[Vector3]
+        external_link_wrenches=None,  # type: Optional[List[Wrench]]
+    ):
+        # type: (...) -> RobotTrajectory
+        """
+        Compute joint torques for each waypoint in a RobotTrajectory message,
+        and store in the point's `effort` field.
+
+        Args:
+            traj_in: Trajectory to compute torques for
+            gravity_vector: Gravity w.r.t. robot model base frame;
+                zero gravity if not specified. Default: None
+            external_link_wrenches: External forces on links; the number of
+                wrenches must match the number of links in the robot model.
+                Zero external wrenches if not specified. Default: None
+
+        Returns:
+            Trajectory with torques stuffed into the `effort` field.
+        """
+        ser_traj_in = conversions.msg_to_string(traj_in)
+
+        ser_gravity_vector = None
+        if gravity_vector is not None:
+            ser_gravity_vector = conversions.msg_to_string(gravity_vector)
+
+        ser_external_link_wrenches = None
+        if external_link_wrenches is not None:
+            ser_external_link_wrenches = [
+                conversions.msg_to_string(w) for w in external_link_wrenches
+            ]
+
+        ser_traj_out = self._g.stuff_torques_into_trajectory(
+            ser_traj_in,
+            ser_gravity_vector,
+            ser_external_link_wrenches,
+        )
+        traj_out = RobotTrajectory()
+        traj_out.deserialize(ser_traj_out)
+        return traj_out
+
     def get_jacobian_matrix(self, joint_values, reference_point=None):
         """Get the jacobian matrix of the group as a list"""
         return self._g.get_jacobian_matrix(

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -547,7 +547,8 @@ public:
   }
 
   // Convert a Python list of deserialized wrench messages to std::vector<geometry_msgs::Wrench>
-  void convertListToArrayOfWrenches(const bp::list& wrenches, std::vector<geometry_msgs::Wrench>& result) {
+  void convertListToArrayOfWrenches(const bp::list& wrenches, std::vector<geometry_msgs::Wrench>& result)
+  {
     int len = bp::len(wrenches);
     result.reserve(len);
     for (int i = 0; i < len; ++i) {
@@ -557,6 +558,7 @@ public:
       result.push_back(wrench_msg);
     }
   }
+
   /**
    * \brief Compute joint torques for each point in a RobotTrajectory message,
    *   and store in the point's `effort` field.
@@ -568,11 +570,11 @@ public:
    *   (default: zero external wrenches for all links)
    *   If specified, the number of wrenches must match the number of links in the robot model.
    *
-   * \return Serialized RobotTrajectory message with torques stuffed into the `effort` field.
+   * \return Serialized RobotTrajectory message with torques injected into the `effort` field.
    */
-  py_bindings_tools::ByteString stuffTorquesIntoTrajectory(const py_bindings_tools::ByteString& traj_str,
-                                                           const bp::object& gravity_vector_obj = bp::object(),
-                                                           const bp::object& external_link_wrenches_obj = bp::object())
+  py_bindings_tools::ByteString injectTrajectoryTorques(const py_bindings_tools::ByteString& traj_str,
+                                                        const bp::object& gravity_vector_obj = bp::object(),
+                                                        const bp::object& external_link_wrenches_obj = bp::object())
   {
     const auto group_name = getName();
     const auto robot_model = getRobotModel();
@@ -585,8 +587,7 @@ public:
     geometry_msgs::Vector3 gravity_vector;  // Default-constructed as zero vector
     if (!gravity_vector_obj.is_none())
     {
-      py_bindings_tools::deserializeMsg(bp::extract<py_bindings_tools::ByteString>(gravity_vector_obj),
-                                        gravity_vector);
+      py_bindings_tools::deserializeMsg(bp::extract<py_bindings_tools::ByteString>(gravity_vector_obj), gravity_vector);
     }
 
     std::vector<geometry_msgs::Wrench> external_link_wrenches;
@@ -606,15 +607,14 @@ public:
 
       try
       {
-        stuffTorquesIntoRobotTrajectoryMsg(traj_msg, robot_model, group_name, gravity_vector,
-                                           external_link_wrenches);
+        injectTorquesIntoRobotTrajectoryMsg(traj_msg, robot_model, group_name, gravity_vector, external_link_wrenches);
       }
       catch (const std::exception& e)
       {
-        ROS_ERROR_NAMED("move_group_py", "Failed to stuff torques into trajectory message: [%s]", e.what());
+        ROS_ERROR_NAMED("move_group_py", "Failed to inject torques into trajectory message: [%s]", e.what());
         return py_bindings_tools::ByteString("");
       }
-    } // End of GILReleaser.
+    }  // End of GILReleaser.
 
     return py_bindings_tools::serializeMsg(traj_msg);
   }
@@ -631,7 +631,7 @@ public:
    *   - iterative_spline_parameterization (ISP)
    *   - time_optimal_trajectory_generation (TOTG)
    *   - iterative_torque_limit_parameterization (ITLP)
-   * \param try_torque_stuffing Whether to compute and store joint torques in retimed trajectory (default: true)
+   * \param try_torque_injection Whether to compute and store joint torques in retimed trajectory (default: true)
    * \param gravity_vector_obj Optional serialized Vector3 message for gravity w.r.t. robot model base frame
    *   (default: zero gravity)
    * \param external_link_wrenches_obj Optional list of serialized Wrench messages for external forces on links
@@ -655,7 +655,7 @@ public:
                                                  const py_bindings_tools::ByteString& traj_str,
                                                  double velocity_scaling_factor, double acceleration_scaling_factor,
                                                  const std::string& algorithm,
-                                                 bool try_torque_stuffing = true,
+                                                 bool try_torque_injection = true,
                                                  const bp::object& gravity_vector_obj = bp::object(),
                                                  const bp::object& external_link_wrenches_obj = bp::object(),
                                                  const bp::object& path_tolerance_obj = bp::object(),
@@ -686,8 +686,7 @@ public:
     geometry_msgs::Vector3 gravity_vector;  // Default-constructed as zero vector
     if (!gravity_vector_obj.is_none())
     {
-      py_bindings_tools::deserializeMsg(bp::extract<py_bindings_tools::ByteString>(gravity_vector_obj),
-                                        gravity_vector);
+      py_bindings_tools::deserializeMsg(bp::extract<py_bindings_tools::ByteString>(gravity_vector_obj), gravity_vector);
     }
 
     std::vector<geometry_msgs::Wrench> external_link_wrenches;
@@ -753,25 +752,25 @@ public:
       }
       else
       {
-        ROS_ERROR_STREAM_NAMED("move_group_py", "Unknown time parameterization algorithm: " << algorithm);
+        ROS_ERROR_STREAM_NAMED("move_group_py", "Unknown time parameterization algorithm!!: " << algorithm);
         return py_bindings_tools::serializeMsg(traj_msg);
       }
 
       traj_obj.getRobotTrajectoryMsg(traj_msg);
 
-      if (try_torque_stuffing)
+      if (try_torque_injection)
       {
         try
         {
-          stuffTorquesIntoRobotTrajectoryMsg(traj_msg, robot_model, group_name, gravity_vector,
-                                             external_link_wrenches);
+          injectTorquesIntoRobotTrajectoryMsg(traj_msg, robot_model, group_name, gravity_vector,
+                                              external_link_wrenches);
         }
         catch (const std::exception& e)
         {
-          ROS_WARN_NAMED("move_group_py", "Failed to stuff torques into trajectory message: [%s]", e.what());
+          ROS_WARN_NAMED("move_group_py", "Failed to inject torques into trajectory message: [%s]", e.what());
         }
       }
-    } // End of GILReleaser.
+    }  // End of GILReleaser.
 
     return py_bindings_tools::serializeMsg(traj_msg);
   }
@@ -827,19 +826,18 @@ private:
    * \note Assumes the joint order in trajectory_msg.joint_trajectory matches the
    *   active joint order in the robot model group.
    */
-  void stuffTorquesIntoRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajectory_msg,
-                                          const robot_model::RobotModelConstPtr& robot_model,
-                                          const std::string& group_name,
-                                          const geometry_msgs::Vector3& gravity_vector,
-                                          const std::vector<geometry_msgs::Wrench>& external_link_wrenches)
+  void injectTorquesIntoRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajectory_msg,
+                                           const robot_model::RobotModelConstPtr& robot_model,
+                                           const std::string& group_name, const geometry_msgs::Vector3& gravity_vector,
+                                           const std::vector<geometry_msgs::Wrench>& external_link_wrenches)
   {
     dynamics_solver::DynamicsSolver dynamics_solver(robot_model, group_name, gravity_vector);
 
     std::vector<double> joint_torques(trajectory_msg.joint_trajectory.joint_names.size());
     for (auto& point : trajectory_msg.joint_trajectory.points)
     {
-      if (dynamics_solver.getTorques(point.positions, point.velocities, point.accelerations,
-                                     external_link_wrenches, joint_torques))
+      if (dynamics_solver.getTorques(point.positions, point.velocities, point.accelerations, external_link_wrenches,
+                                     joint_torques))
       {
         point.effort = joint_torques;
       }
@@ -982,7 +980,7 @@ static void wrap_move_group_interface()
   move_group_interface_class.def("set_support_surface_name", &MoveGroupInterfaceWrapper::setSupportSurfaceName);
   move_group_interface_class.def("attach_object", &MoveGroupInterfaceWrapper::attachObjectPython);
   move_group_interface_class.def("detach_object", &MoveGroupInterfaceWrapper::detachObject);
-  move_group_interface_class.def("stuff_torques_into_trajectory", &MoveGroupInterfaceWrapper::stuffTorquesIntoTrajectory);
+  move_group_interface_class.def("inject_trajectory_torques", &MoveGroupInterfaceWrapper::injectTrajectoryTorques);
   move_group_interface_class.def("retime_trajectory", &MoveGroupInterfaceWrapper::retimeTrajectory);
   move_group_interface_class.def("get_named_targets", &MoveGroupInterfaceWrapper::getNamedTargetsPython);
   move_group_interface_class.def("get_named_target_values", &MoveGroupInterfaceWrapper::getNamedTargetValuesPython);

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -557,39 +557,66 @@ public:
       result.push_back(wrench_msg);
     }
   }
-
   /**
-   * \brief Computes joint torques for each waypoint in a RobotTrajectory message
-   *   and stores them in the effort field.
+   * \brief Compute joint torques for each point in a RobotTrajectory message,
+   *   and store in the point's `effort` field.
    *
-   * \param[in,out] trajectory_msg The trajectory to compute torques for (the effort field will be overwritten)
-   * \param robot_model The robot model to use for dynamics calculations.
-   * \param group_name Name of the joint group to compute torques for.
-   * \param gravity_vector The gravity vector to use in dynamics calculations.
-   * \param external_link_wrenches External wrenches (force/torque) acting on each link.
+   * \param traj_str Serialized RobotTrajectory message to compute torques for
+   * \param gravity_vector_obj Optional serialized Vector3 message for gravity w.r.t. robot model base frame
+   *   (default: zero gravity)
+   * \param external_link_wrenches_obj Optional list of serialized Wrench messages for external forces on links
+   *   (default: zero external wrenches for all links)
+   *   If specified, the number of wrenches must match the number of links in the robot model.
    *
-   * \note No input validation is performed -- recommend calling in a try/catch.
-   * \note Assumes the joint order in trajectory_msg.joint_trajectory matches the
-   *   active joint order in the robot model group.
-   * TODO(cj): Provide a binding and expose this to MoveGroupInterface.
+   * \return Serialized RobotTrajectory message with torques stuffed into the `effort` field.
    */
-  void stuffTorquesIntoRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajectory_msg,
-                                          const robot_model::RobotModelConstPtr& robot_model,
-                                          const std::string& group_name,
-                                          const geometry_msgs::Vector3& gravity_vector,
-                                          const std::vector<geometry_msgs::Wrench>& external_link_wrenches)
+  py_bindings_tools::ByteString stuffTorquesIntoTrajectory(const py_bindings_tools::ByteString& traj_str,
+                                                           const bp::object& gravity_vector_obj = bp::object(),
+                                                           const bp::object& external_link_wrenches_obj = bp::object())
   {
-    dynamics_solver::DynamicsSolver dynamics_solver(robot_model, group_name, gravity_vector);
+    const auto group_name = getName();
+    const auto robot_model = getRobotModel();
 
-    std::vector<double> joint_torques(trajectory_msg.joint_trajectory.joint_names.size());
-    for (auto& point : trajectory_msg.joint_trajectory.points)
+    // Convert the python arguments to C++ objects.
+    // Need to do these conversions before GIL is released!
+    moveit_msgs::RobotTrajectory traj_msg;
+    py_bindings_tools::deserializeMsg(traj_str, traj_msg);
+
+    geometry_msgs::Vector3 gravity_vector;  // Default-constructed as zero vector
+    if (!gravity_vector_obj.is_none())
     {
-      if (dynamics_solver.getTorques(point.positions, point.velocities, point.accelerations,
-                                     external_link_wrenches, joint_torques))
-      {
-        point.effort = joint_torques;
-      }
+      py_bindings_tools::deserializeMsg(bp::extract<py_bindings_tools::ByteString>(gravity_vector_obj),
+                                        gravity_vector);
     }
+
+    std::vector<geometry_msgs::Wrench> external_link_wrenches;
+    if (!external_link_wrenches_obj.is_none())
+    {
+      convertListToArrayOfWrenches(bp::extract<bp::list>(external_link_wrenches_obj), external_link_wrenches);
+    }
+    if (external_link_wrenches.empty())
+    {
+      const robot_model::JointModelGroup* group = robot_model->getJointModelGroup(group_name);
+      external_link_wrenches.resize(group ? group->getLinkModelNames().size() : 0);
+    }
+
+    // Release GIL and do the actual torque computation.
+    {
+      GILReleaser gr;
+
+      try
+      {
+        stuffTorquesIntoRobotTrajectoryMsg(traj_msg, robot_model, group_name, gravity_vector,
+                                           external_link_wrenches);
+      }
+      catch (const std::exception& e)
+      {
+        ROS_ERROR_NAMED("move_group_py", "Failed to stuff torques into trajectory message: [%s]", e.what());
+        return py_bindings_tools::ByteString("");
+      }
+    } // End of GILReleaser.
+
+    return py_bindings_tools::serializeMsg(traj_msg);
   }
 
   /**
@@ -784,6 +811,40 @@ public:
       return py_bindings_tools::ByteString("");
     }
   }
+
+private:
+  /**
+   * \brief Computes joint torques for each waypoint in a RobotTrajectory message
+   *   and stores them in the effort field.
+   *
+   * \param[in,out] trajectory_msg The trajectory to compute torques for (the effort field will be overwritten)
+   * \param robot_model The robot model to use for dynamics calculations.
+   * \param group_name Name of the joint group to compute torques for.
+   * \param gravity_vector The gravity vector to use in dynamics calculations.
+   * \param external_link_wrenches External wrenches (force/torque) acting on each link.
+   *
+   * \note No input validation is performed -- recommend calling in a try/catch.
+   * \note Assumes the joint order in trajectory_msg.joint_trajectory matches the
+   *   active joint order in the robot model group.
+   */
+  void stuffTorquesIntoRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajectory_msg,
+                                          const robot_model::RobotModelConstPtr& robot_model,
+                                          const std::string& group_name,
+                                          const geometry_msgs::Vector3& gravity_vector,
+                                          const std::vector<geometry_msgs::Wrench>& external_link_wrenches)
+  {
+    dynamics_solver::DynamicsSolver dynamics_solver(robot_model, group_name, gravity_vector);
+
+    std::vector<double> joint_torques(trajectory_msg.joint_trajectory.joint_names.size());
+    for (auto& point : trajectory_msg.joint_trajectory.points)
+    {
+      if (dynamics_solver.getTorques(point.positions, point.velocities, point.accelerations,
+                                     external_link_wrenches, joint_torques))
+      {
+        point.effort = joint_torques;
+      }
+    }
+  }
 };
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getJacobianMatrixOverloads, getJacobianMatrixPython, 1, 2)
@@ -921,6 +982,7 @@ static void wrap_move_group_interface()
   move_group_interface_class.def("set_support_surface_name", &MoveGroupInterfaceWrapper::setSupportSurfaceName);
   move_group_interface_class.def("attach_object", &MoveGroupInterfaceWrapper::attachObjectPython);
   move_group_interface_class.def("detach_object", &MoveGroupInterfaceWrapper::detachObject);
+  move_group_interface_class.def("stuff_torques_into_trajectory", &MoveGroupInterfaceWrapper::stuffTorquesIntoTrajectory);
   move_group_interface_class.def("retime_trajectory", &MoveGroupInterfaceWrapper::retimeTrajectory);
   move_group_interface_class.def("get_named_targets", &MoveGroupInterfaceWrapper::getNamedTargetsPython);
   move_group_interface_class.def("get_named_target_values", &MoveGroupInterfaceWrapper::getNamedTargetValuesPython);


### PR DESCRIPTION
This PR exposes a standalone method in `MoveGroupCommander` to stuff torques into a `RobotTrajectory.msg`; the C++ method is `stuffTorquesIntoTrajectory`, and the python binding is `stuff_torques_into_trajectory`.

### Testing
- [x] `moveit_commander` package builds successfully
- [x] `retimeTrajectory` with torque stuffing still WAI
- [x] `stuff_torques_into_trajectory` WAI