### PR TITLE
:stopwatch: :tada: Optionally pass joint velocity and acceleration limits to retiming

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -32,6 +32,7 @@
 #
 # Author: Ioan Sucan, William Baker
 
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -736,13 +737,15 @@ class MoveGroupCommander(object):
         velocity_scaling_factor=1.0,  # type: float
         acceleration_scaling_factor=1.0,  # type: float
         algorithm="iterative_time_parameterization",  # type: str
+        joint_velocity_limits=None,  # type: Optional[Dict[str, float]]
+        joint_acceleration_limits=None,  # type: Optional[Dict[str, float]]
+        joint_torque_limits=None,  # type: Optional[List[float]]
         try_torque_injection=True,  # type: bool
         gravity_vector=None,  # type: Optional[Vector3]
         external_link_wrenches=None,  # type: Optional[List[Wrench]]
         path_tolerance=None,  # type: Optional[float]
         resample_dt=None,  # type: Optional[float]
         min_angle_change=None,  # type: Optional[float]
-        joint_torque_limits=None,  # type: Optional[List[float]]
         accel_limit_decrement_factor=None,  # type: Optional[float]
         max_iterations=None,  # type: Optional[int]
     ):
@@ -763,6 +766,15 @@ class MoveGroupCommander(object):
                 - "iterative_spline_parameterization" (ISP)
                 - "time_optimal_trajectory_generation" (TOTG)
                 - "iterative_torque_limit_parameterization" (ITLP)
+            joint_velocity_limits: Dictionary mapping joint names to velocity
+                limits (rad/s or m/s). Overrides RobotModel limits for any joint
+                provided. Default: None (use RobotModel limits for all joints).
+            joint_acceleration_limits: Dictionary mapping joint names to
+                acceleration limits (rad/s^2 or m/s^2). Overrides RobotModel
+                limits for any joint provided. Default: None (use RobotModel
+                limits for all joints).
+            joint_torque_limits: Joint torque limits (Nm) for ITLP; required for
+                ITLP!
             try_torque_injection: Whether to compute and store joint torques
                 in the returned trajectory. Default: True
             gravity_vector: Gravity w.r.t. robot model base frame;
@@ -779,8 +791,6 @@ class MoveGroupCommander(object):
             min_angle_change: Minimum angle change (rad) for TOTG/ITLP;
                 if not specified, a default value is used. See TOTG/ITLP docs
                 for details and default.
-            joint_torque_limits: Joint torque limits (Nm) for ITLP;
-                Required for ITLP!
             accel_limit_decrement_factor: Acceleration limit decrement factor
                 for ITLP; if not specified, a default value is used. See
                 ITLP docs for details and default.
@@ -810,13 +820,15 @@ class MoveGroupCommander(object):
             velocity_scaling_factor,
             acceleration_scaling_factor,
             algorithm,
+            joint_velocity_limits,
+            joint_acceleration_limits,
+            joint_torque_limits,
             try_torque_injection,
             ser_gravity_vector,
             ser_external_link_wrenches,
             path_tolerance,
             resample_dt,
             min_angle_change,
-            joint_torque_limits,
             accel_limit_decrement_factor,
             max_iterations,
         )

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_torque_limit_parameterization.h
@@ -38,6 +38,7 @@
 
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <boost/optional.hpp>
+#include <unordered_map>
 
 namespace trajectory_processing
 {
@@ -50,31 +51,56 @@ public:
                                        boost::optional<double> min_angle_change = boost::none);
 
   /**
-   * \brief Compute a trajectory with waypoints spaced equally in time (according to resample_dt_).
-   * Resampling the trajectory doesn't change the start and goal point,
-   * and all re-sampled waypoints will be on the path of the original trajectory (within path_tolerance_).
-   * However, controller execution is separate from MoveIt and may deviate from the intended path between waypoints.
-   * path_tolerance_ is defined in configuration space, so the unit is rad for revolute joints,
-   * meters for prismatic joints.
-   * \param[in,out] trajectory A path which needs time-parameterization. It's OK if this path has already been
-   * time-parameterized; this function will re-time-parameterize it.
-   * \param gravity_vector W.r.t. the robot's base frame. Units are m/s^2
-   * \param external_link_wrenches Externally-applied wrenches on each link. TODO(andyz): what frame is this in?
-   * \param joint_torque_limits Torque limits for each joint in N*m. All should be >0.
-   * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
-   * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
-   * \param accel_limit_decrement_factor Must be in the range [0.01, 0.2]. If not specified, default is 0.1.
-   *   This affects how fast acceleration limits are decreased while searching for a solution.
-   *   Time-optimality of the output is accurate to approximately (100*accel_limit_decrement_factor)%.
-   *   For example, if accel_limit_decrement_factor is 0.1, the output should be within 10% of time-optimal.
-   * \param max_iterations Maximum number of times to do the TOTG->torque check->accel change loop.
-   *   If not specified, default is 10.
-   * \param reset_traj_after_max_iterations Whether to reset `trajectory` to its initial state when more than
-   *   `max_iterations` iterations is needed to get all torques under their limits. If not specified, default is false.
+   * \brief See computeTimeStampsWithTorqueLimits(trajectory, velocity_limits, acceleration_limits, ...) for docs.
    */
   bool computeTimeStampsWithTorqueLimits(
-      robot_trajectory::RobotTrajectory& trajectory, const geometry_msgs::Vector3& gravity_vector,
-      const std::vector<geometry_msgs::Wrench>& external_link_wrenches, const std::vector<double>& joint_torque_limits,
+      robot_trajectory::RobotTrajectory& trajectory, const std::vector<double>& torque_limits,
+      const geometry_msgs::Vector3& gravity_vector,
+      const std::vector<geometry_msgs::Wrench>& external_link_wrenches,
+      const double max_velocity_scaling_factor, const double max_acceleration_scaling_factor,
+      boost::optional<double> accel_limit_decrement_factor = boost::none,
+      boost::optional<size_t> max_iterations = boost::none,
+      boost::optional<bool> reset_trajectory_after_max_iterations = boost::none) const
+  {
+    // Delegate to the overload that accepts custom velocity and acceleration limits, using empty maps
+    // to indicate that RobotModel limits should be used.
+    std::unordered_map<std::string, double> empty_velocity_limits;
+    std::unordered_map<std::string, double> empty_acceleration_limits;
+    return computeTimeStampsWithTorqueLimits(trajectory, empty_velocity_limits, empty_acceleration_limits,
+                                             torque_limits, gravity_vector, external_link_wrenches,
+                                             max_velocity_scaling_factor, max_acceleration_scaling_factor,
+                                             accel_limit_decrement_factor, max_iterations,
+                                             reset_trajectory_after_max_iterations);
+  }
+
+  /**
+   * \brief Compute a trajectory with waypoints spaced equally in time (according to resample_dt_).
+   * \param[in,out] trajectory A path which needs time-parameterization. It's OK if this path has already been
+   * time-parameterized; this function will re-time-parameterize it.
+   * \param velocity_limits Joint names and velocity limits [rad/s, m/s].
+   * \param acceleration_limits Joint names and acceleration limits [rad/s^2, m/s^2].
+   * \param torque_limits Torque limits for each joint (all should be > 0) [N*m].
+   * \param gravity_vector Orientation of the gravity vector w.r.t. the RobotModel's base frame [m/s^2].
+   * \param external_link_wrenches Externally-applied wrenches on each link. TODO(andyz): what frame is this in?
+   * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param accel_limit_decrement_factor (Optional) How much to change the acceleration limits every iteration.
+   *   Time-optimality of the output is accurate to approximately (100*accel_limit_decrement_factor)%. For example, if
+   *   accel_limit_decrement_factor is 0.1, the output should be within 10% of time-optimal. Must be > 0.01. If not
+   *   specified, default is 0.1.
+   * \param max_iterations (Optional) Maximum number of times to do the TOTG->torque check->accel change loop. If not
+   *   specified, default is 10.
+   * \param reset_traj_after_max_iterations (Optional) Whether to reset `trajectory` to its initial state when more
+   *   than `max_iterations` iterations is needed to get all torques under their limits. If not specified, default is
+   *   false.
+   */
+  bool computeTimeStampsWithTorqueLimits(
+      robot_trajectory::RobotTrajectory& trajectory,
+      const std::unordered_map<std::string, double>& velocity_limits,
+      const std::unordered_map<std::string, double>& acceleration_limits,
+      const std::vector<double>& torque_limits,
+      const geometry_msgs::Vector3& gravity_vector,
+      const std::vector<geometry_msgs::Wrench>& external_link_wrenches,
       const double max_velocity_scaling_factor, const double max_acceleration_scaling_factor,
       boost::optional<double> accel_limit_decrement_factor = boost::none,
       boost::optional<size_t> max_iterations = boost::none,

--- a/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_torque_limit_parameterization.cpp
@@ -35,6 +35,7 @@
 
 #include <moveit/dynamics_solver/dynamics_solver.h>
 #include "moveit/trajectory_processing/iterative_torque_limit_parameterization.h"
+#include <unordered_map>
 
 namespace trajectory_processing
 {
@@ -53,8 +54,12 @@ IterativeTorqueLimitParameterization::IterativeTorqueLimitParameterization(boost
 }
 
 bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
-    robot_trajectory::RobotTrajectory& trajectory, const geometry_msgs::Vector3& gravity_vector,
-    const std::vector<geometry_msgs::Wrench>& external_link_wrenches, const std::vector<double>& joint_torque_limits,
+    robot_trajectory::RobotTrajectory& trajectory,
+    const std::unordered_map<std::string, double>& velocity_limits,
+    const std::unordered_map<std::string, double>& acceleration_limits,
+    const std::vector<double>& torque_limits,
+    const geometry_msgs::Vector3& gravity_vector,
+    const std::vector<geometry_msgs::Wrench>& external_link_wrenches,
     const double max_velocity_scaling_factor, const double max_acceleration_scaling_factor,
     boost::optional<double> accel_limit_decrement_factor, boost::optional<size_t> max_iterations,
     boost::optional<bool> reset_trajectory_after_max_iterations) const
@@ -79,17 +84,17 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
 
   const size_t dof = group->getActiveJointModels().size();
 
-  if (joint_torque_limits.size() != dof)
+  if (torque_limits.size() != dof)
   {
-    ROS_ERROR_STREAM_NAMED(LOGNAME, "Joint torque limit vector size (" << joint_torque_limits.size()
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Joint torque limit vector size (" << torque_limits.size()
                                                                        << ") does not match the DOF of the RobotModel ("
                                                                        << dof << ")");
     return false;
   }
 
-  if (accel_decrement_factor < 0.01 || accel_decrement_factor > 0.2)
+  if (accel_decrement_factor < 0.01)
   {
-    ROS_ERROR_NAMED(LOGNAME, "The accel_limit_decrement_factor is outside the typical range [0.01, 0.2]");
+    ROS_ERROR_NAMED(LOGNAME, "accel_limit_decrement_factor must be > 0.01");
     return false;
   }
 
@@ -104,13 +109,16 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     return true;
   };
 
+  /* Create a mutable copy of `velocity_limits` and `acceleration_limits`;
+   * fill them in from the robot description if they are empty.
+   * TODO(cj): Factor out limit resolution; common/duplicated in TOTG as well.
+   */
+  std::unordered_map<std::string, double> mutable_velocity_limits = velocity_limits;
+  std::unordered_map<std::string, double> mutable_acceleration_limits = acceleration_limits;
+
   const std::vector<std::string>& joint_names = group->getActiveJointModelNames();
   size_t num_joints = joint_names.size();
   const robot_model::JointBoundsVector joint_bounds = group->getActiveJointModelsBounds();
-
-  // TODO(cj): Factor out limit resolution; common/duplicated in TOTG as well.
-  std::unordered_map<std::string, double> velocity_limits;
-  std::unordered_map<std::string, double> mutable_acceleration_limits;
 
   for (size_t j = 0; j < num_joints; ++j)
   {
@@ -124,36 +132,48 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     }
     const moveit::core::VariableBounds vb = (*bounds_ptr)[0];
 
-    // Resolve velocity limit
-    if (vb.velocity_bounded_)
+    auto it = mutable_velocity_limits.find(name);
+    if (it == mutable_velocity_limits.end())
     {
-      double limit = std::min(std::fabs(vb.max_velocity_), std::fabs(vb.min_velocity_));
-      if (!validate_limit("velocity", limit, name))
+      if (vb.velocity_bounded_)
       {
-        return false;
+        double limit = std::min(std::fabs(vb.max_velocity_), std::fabs(vb.min_velocity_));
+        if (!validate_limit("velocity", limit, name))
+          return false;
+        mutable_velocity_limits[name] = limit;
       }
-      velocity_limits[name] = limit;
+      else
+      {
+        mutable_velocity_limits[name] = DEFAULT_VELOCITY_LIMIT;
+        ROS_WARN_ONCE_NAMED(LOGNAME,
+          "No velocity limits defined for '%s'! Define them in URDF or joint_limits.yaml", name.c_str());
+      }
     }
-    else
-    {
-      velocity_limits[name] = DEFAULT_VELOCITY_LIMIT;
-      ROS_WARN_ONCE_NAMED(LOGNAME, "No velocity limits defined for '%s'! Define them in the URDF.", name.c_str());
+    else {
+      if (!validate_limit("velocity", it->second, name))
+        return false;
     }
 
-    // Resolve acceleration limit
-    if (vb.acceleration_bounded_)
+    it = mutable_acceleration_limits.find(name);
+    if (it == mutable_acceleration_limits.end())
     {
-      double limit = std::min(std::fabs(vb.max_acceleration_), std::fabs(vb.min_acceleration_));
-      if (!validate_limit("acceleration", limit, name))
+      if (vb.acceleration_bounded_)
       {
-        return false;
+        double limit = std::min(std::fabs(vb.max_acceleration_), std::fabs(vb.min_acceleration_));
+        if (!validate_limit("acceleration", limit, name))
+          return false;
+        mutable_acceleration_limits[name] = limit;
       }
-      mutable_acceleration_limits[name] = limit;
+      else
+      {
+        mutable_acceleration_limits[name] = DEFAULT_ACCELERATION_LIMIT;
+        ROS_WARN_ONCE_NAMED(LOGNAME,
+          "No acceleration limits defined for '%s'! Define them in joint_limits.yaml", name.c_str());
+      }
     }
-    else
-    {
-      mutable_acceleration_limits[name] = DEFAULT_ACCELERATION_LIMIT;
-      ROS_WARN_ONCE_NAMED(LOGNAME, "No acceleration limits defined for '%s'! Define them in the URDF.", name.c_str());
+    else {
+      if (!validate_limit("acceleration", it->second, name))
+        return false;
     }
   }
 
@@ -175,8 +195,8 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
     // TOTG is always run on the same trajectory;
     // `mutable_acceleration_limits` is the only thing changing across iterations.
     trajectory.setRobotTrajectoryMsg(initial_state, original_traj);
-    totg_.computeTimeStamps(trajectory, velocity_limits, mutable_acceleration_limits, max_velocity_scaling_factor,
-                            max_acceleration_scaling_factor);
+    totg_.computeTimeStamps(trajectory, mutable_velocity_limits, mutable_acceleration_limits,
+                            max_velocity_scaling_factor, max_acceleration_scaling_factor);
 
     std::vector<double> joint_positions(dof);
     std::vector<double> joint_velocities(dof);
@@ -201,9 +221,9 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
       }
 
       // For each joint, check if torque exceeds the limit
-      for (size_t joint_idx = 0; joint_idx < joint_torque_limits.size(); ++joint_idx)
+      for (size_t joint_idx = 0; joint_idx < torque_limits.size(); ++joint_idx)
       {
-        if (std::fabs(joint_torques.at(joint_idx)) > joint_torque_limits.at(joint_idx))
+        if (std::fabs(joint_torques.at(joint_idx)) > torque_limits.at(joint_idx))
         {
           // We can't always just decrease acceleration to decrease joint torque.
           // There are some edge cases where decreasing acceleration could actually increase joint torque. For example,
@@ -242,7 +262,7 @@ bool IterativeTorqueLimitParameterization::computeTimeStampsWithTorqueLimits(
         break;
       }
     }  // for each waypoint
-      }  // while (iteration_needed && num_iterations < max_iter)
+  }  // while (iteration_needed && num_iterations < max_iter)
 
   if (num_iterations >= max_iter && iteration_needed)
   {

--- a/moveit_core/trajectory_processing/test/test_iterative_torque_limit_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_iterative_torque_limit_parameterization.cpp
@@ -114,7 +114,7 @@ TEST(time_optimal_trajectory_generation, test_totg_with_torque_limits)
   }();
 
   bool totg_success =
-      totg.computeTimeStampsWithTorqueLimits(trajectory, gravity_vector, external_link_wrenches, joint_torque_limits,
+      totg.computeTimeStampsWithTorqueLimits(trajectory, joint_torque_limits, gravity_vector, external_link_wrenches,
                                              1.0 /* vel scaling */, 1.0 /* accel scaling */,
                                              accel_limit_decrement_factor);
   ASSERT_TRUE(totg_success) << "Failed to compute timestamps";
@@ -123,7 +123,7 @@ TEST(time_optimal_trajectory_generation, test_totg_with_torque_limits)
   // Now decrease joint torque limits and re-time-parameterize. The trajectory duration should be longer.
   const std::vector<double> lower_torque_limits{ 1 };  // in N*m
   totg_success =
-      totg.computeTimeStampsWithTorqueLimits(trajectory, gravity_vector, external_link_wrenches, lower_torque_limits,
+      totg.computeTimeStampsWithTorqueLimits(trajectory, lower_torque_limits, gravity_vector, external_link_wrenches,
                                              1.0 /* vel scaling */, 1.0 /* accel scaling */,
                                              accel_limit_decrement_factor);
   ASSERT_TRUE(totg_success) << "Failed to compute timestamps";

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -34,6 +34,9 @@
 
 /* Author: Ioan Sucan */
 
+// Default Boost Python max arity is 15, but `retimeTrajectory` has 16 arguments, so we increase it.
+#define BOOST_PYTHON_MAX_ARITY 16
+
 #include <moveit/dynamics_solver/dynamics_solver.h>
 #include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/py_bindings_tools/roscpp_initializer.h>
@@ -56,6 +59,7 @@
 #include <eigenpy/eigenpy.hpp>
 #include <memory>
 #include <Python.h>
+#include <unordered_map>
 
 /** @cond IGNORE */
 
@@ -631,6 +635,11 @@ public:
    *   - iterative_spline_parameterization (ISP)
    *   - time_optimal_trajectory_generation (TOTG)
    *   - iterative_torque_limit_parameterization (ITLP)
+   * \param joint_velocity_limits_obj Optional dict of joint names to velocity limits (rad/s or m/s);
+   *   overrides RobotModel limits for any joint provided. Default: None (use RobotModel limits for all joints).
+   * \param joint_acceleration_limits_obj Optional dict of joint names to acceleration limits (rad/s^2 or m/s^2);
+   *   overrides RobotModel limits for any joint provided. Default: None (use RobotModel limits for all joints).
+   * \param joint_torque_limits_obj Optional list of doubles for ITLP joint torque limits (Nm); required for ITLP.
    * \param try_torque_injection Whether to compute and store joint torques in retimed trajectory (default: true)
    * \param gravity_vector_obj Optional serialized Vector3 message for gravity w.r.t. robot model base frame
    *   (default: zero gravity)
@@ -643,7 +652,6 @@ public:
    *   see TOTG/ITLP docs for details and default.
    * \param min_angle_change_obj Optional double for TOTG/ITLP minimum angle change (rad);
    *   see TOTG/ITLP docs for details and default.
-   * \param joint_torque_limits_obj Optional list of doubles for ITLP joint torque limits (Nm); required for ITLP.
    * \param accel_limit_decrement_factor_obj Optional double for ITLP acceleration limit decrement factor;
    *   see ITLP docs for details and default.
    * \param max_iterations_obj Optional int for ITLP maximum number of iterations;
@@ -653,15 +661,18 @@ public:
    */
   py_bindings_tools::ByteString retimeTrajectory(const py_bindings_tools::ByteString& ref_state_str,
                                                  const py_bindings_tools::ByteString& traj_str,
-                                                 double velocity_scaling_factor, double acceleration_scaling_factor,
+                                                 double velocity_scaling_factor,
+                                                 double acceleration_scaling_factor,
                                                  const std::string& algorithm,
+                                                 const bp::object& joint_velocity_limits_obj = bp::object(),
+                                                 const bp::object& joint_acceleration_limits_obj = bp::object(),
+                                                 const bp::object& joint_torque_limits_obj = bp::object(),
                                                  bool try_torque_injection = true,
                                                  const bp::object& gravity_vector_obj = bp::object(),
                                                  const bp::object& external_link_wrenches_obj = bp::object(),
                                                  const bp::object& path_tolerance_obj = bp::object(),
                                                  const bp::object& resample_dt_obj = bp::object(),
                                                  const bp::object& min_angle_change_obj = bp::object(),
-                                                 const bp::object& joint_torque_limits_obj = bp::object(),
                                                  const bp::object& accel_limit_decrement_factor_obj = bp::object(),
                                                  const bp::object& max_iterations_obj = bp::object())
   {
@@ -700,6 +711,18 @@ public:
       external_link_wrenches.resize(group ? group->getLinkModelNames().size() : 0);
     }
 
+    // Convert joint velocity, acceleration, and torque limits from Python to C++ objects.
+    std::unordered_map<std::string, double> joint_velocity_limits;
+    if (!joint_velocity_limits_obj.is_none())
+    {
+      joint_velocity_limits = py_bindings_tools::unorderedMapFromDict<std::string, double>(joint_velocity_limits_obj);
+    }
+    std::unordered_map<std::string, double> joint_acceleration_limits;
+    if (!joint_acceleration_limits_obj.is_none())
+    {
+      joint_acceleration_limits =
+          py_bindings_tools::unorderedMapFromDict<std::string, double>(joint_acceleration_limits_obj);
+    }
     std::vector<double> joint_torque_limits;
     if (!joint_torque_limits_obj.is_none())
     {
@@ -739,16 +762,17 @@ public:
       {
         trajectory_processing::IterativeTorqueLimitParameterization time_param(path_tolerance, resample_dt,
                                                                                min_angle_change);
-        time_param.computeTimeStampsWithTorqueLimits(traj_obj, gravity_vector, external_link_wrenches,
-                                                     joint_torque_limits, velocity_scaling_factor,
-                                                     acceleration_scaling_factor, accel_limit_decrement_factor,
-                                                     max_iterations);
+        time_param.computeTimeStampsWithTorqueLimits(traj_obj, joint_velocity_limits, joint_acceleration_limits,
+                                                     joint_torque_limits, gravity_vector, external_link_wrenches,
+                                                     velocity_scaling_factor, acceleration_scaling_factor,
+                                                     accel_limit_decrement_factor, max_iterations);
       }
       else if (algorithm == "time_optimal_trajectory_generation")
       {
         trajectory_processing::TimeOptimalTrajectoryGeneration time_param(path_tolerance, resample_dt,
                                                                           min_angle_change);
-        time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
+        time_param.computeTimeStamps(traj_obj, joint_velocity_limits, joint_acceleration_limits,
+                                     velocity_scaling_factor, acceleration_scaling_factor);
       }
       else
       {

--- a/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/py_conversions.h
+++ b/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/py_conversions.h
@@ -42,6 +42,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_map>
 
 namespace moveit
 {
@@ -93,6 +94,23 @@ boost::python::list listFromString(const std::vector<std::string>& v)
 {
   return listFromType<std::string>(v);
 }
+
+template <typename K, typename V>
+std::unordered_map<K, V> unorderedMapFromDict(const boost::python::object& obj)
+{
+  boost::python::dict d = boost::python::extract<boost::python::dict>(obj);
+  std::unordered_map<K, V> result;
+  boost::python::list keys = d.keys();
+  int num_keys = boost::python::len(keys);
+  for (int i = 0; i < num_keys; ++i)
+  {
+    K key = boost::python::extract<K>(keys[i]);
+    V value = boost::python::extract<V>(d[keys[i]]);
+    result[key] = value;
+  }
+  return result;
+}
+
 }  // namespace py_bindings_tools
 }  // namespace moveit
 


### PR DESCRIPTION
Towards [SW-2335](https://linear.app/chef-robotics/issue/SW-2335)

### Description

Updates `retimeTrajectory` to allow caller to pass joint velocity and acceleration limits; applies to TOTG and ITLP (those are the only retiming algos that currently support joint velocity and acceleration limits). Normally these limits are loaded from the RobotModel, which for us is defined by the URDF; retiming will use the RobotModel limits for any joint that isn't in the user-specified limits.

Other changes:
- Renamed `joint_torque_limits` to `torque_limits` within ITLP.
- Removed the upper bound (0.2) on `accel_decrement_factor` .


### Tests
- [x] `moveit` builds successfully
- [x] TOTG and ITLP unit tests pass
- [x] User-specified velocity and acceleration limits are passed on to TOTG and ITLP.

Example where wrist3 velocity and acceleration are both halved (the "TOTG" and "ITLP" labels are wrong -- consider "TOTG" the "no user-specified limits", and "ITLP" the "use-specified limits")
<img width="2269" height="1255" alt="image" src="https://github.com/user-attachments/assets/ff11eb35-78a1-4323-b2ec-ef1729920358" />
You can see velocity and acceleration are correctly limited to half their values, as specified.